### PR TITLE
feat: add JetBrains Toolbox Linux cask and CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: brew pr-pull
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  pr-pull:
+    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up git
+        uses: Homebrew/actions/git-user-config@main
+
+      - name: Pull bottles
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@main
+        with:
+          branch: main
+
+      - name: Delete branch
+        if: github.event.pull_request.head.repo.fork == false
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: brew test-bot
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-bot:
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Homebrew Bundler RubyGems
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - run: brew test-bot --only-tap-syntax
+      - run: brew test-bot --only-formulae
+        if: github.event_name == 'pull_request'
+
+      - name: Upload bottles as artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bottles_${{ matrix.os }}
+          path: '*.bottle.*'

--- a/Casks/j/jetbrains-toolbox-linux.rb
+++ b/Casks/j/jetbrains-toolbox-linux.rb
@@ -1,0 +1,42 @@
+cask "jetbrains-toolbox-linux" do
+  version "2.8.1.52155"
+  sha256 "23fc2af0aed0d59a894399e651eec942c7711f89f5d3b6d548ef6ba3358f01e5"
+
+  url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.tar.gz"
+  name "JetBrains Toolbox"
+  desc "JetBrains tools manager"
+  homepage "https://www.jetbrains.com/toolbox-app/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release"
+    strategy :json do |json|
+      json["TBA"]&.map { |release| release["build"] }
+    end
+  end
+
+  auto_updates true
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    File.write("#{staged_path}/jetbrains-toolbox-#{version}/jetbrains-toolbox.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=JetBrains Toolbox
+      Comment=JetBrains tools manager
+      GenericName=Development Tools Manager
+      Exec=#{HOMEBREW_PREFIX}/bin/jetbrains-toolbox
+      Icon=jetbrains-toolbox
+      Type=Application
+      StartupNotify=false
+      StartupWMClass=JetBrains Toolbox
+      Categories=Development;IDE;
+      Keywords=jetbrains;toolbox;ide;
+    EOS
+  end
+
+  # Correct binary path inside the tarball
+  binary "#{staged_path}/jetbrains-toolbox-#{version}/bin/jetbrains-toolbox"
+
+  zap trash: [
+    "~/.config/JetBrains/ToolboxApp",
+  ]
+end


### PR DESCRIPTION
- Add JetBrains Toolbox Linux cask for managing JetBrains IDEs
- Set up GitHub workflows for Homebrew tap automation
