### PR TITLE
docs(readme): update JetBrains Toolbox Linux cask name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ IDEs like Jetbrains and VSCode. They don't run well out of flatpaks so we put th
 
 ```shell
 brew tap ublue-os/tap
-brew install jetbrains-toolbox
+brew install jetbrains-toolbox-linux
 ```
 ## Includes
 


### PR DESCRIPTION
Corrects the cask name for JetBrains Toolbox to `jetbrains-toolbox-linux` as per official Homebrew formulae non conflict naming.