### PR TITLE
Change 1password to use the tar.gz release and other fixes

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -1,64 +1,58 @@
+module Utils
+  def self.alternate_arch(arch)
+    case arch
+    when "aarch64"
+      "arm64"
+    when "x86_64"
+      "x64"
+    end
+  end
+
+  def self.replace_path_in_file(file_path, old_text, new_text)
+    text = File.read(file_path)
+    new_contents = text.gsub(old_text, new_text)
+    File.open(file_path, "w") { |file| file.puts new_contents }
+  end
+end
+
 cask "1password-gui-linux" do
+  arch intel: "x86_64", arm: "aarch64"
+  os linux: "linux"
+
   version "8.11.8"
   sha256 :no_check
 
-  url "https://downloads.1password.com/linux/rpm/stable/x86_64/1password-latest.rpm"
+  url "https://downloads.1password.com/#{os}/tar/stable/#{arch}/1password-latest.tar.gz"
   name "1Password"
   desc "Password manager that keeps all passwords secure behind one password"
   homepage "https://1password.com/"
 
-  auto_updates true
-
-  binary "#{staged_path}/1password-extracted/opt/1Password/1password", target: "1password"
-
-  preflight do
-    rpm_file = "#{staged_path}/1password-latest.rpm"
-
-    extract_dir = "#{staged_path}/1password-extracted"
-    FileUtils.mkdir_p extract_dir
-
-    system "cd '#{extract_dir}' && rpm2cpio '#{rpm_file}' | cpio -idmv"
-
-    FileUtils.rm rpm_file
-  end
-
-  postflight do
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons"
-
-    icon_source = "#{staged_path}/1password-extracted/usr/share/icons/hicolor/256x256/apps/1password.png"
-    icon_target = "#{Dir.home}/.local/share/icons/1password.png"
-
-    FileUtils.cp icon_source, icon_target if File.exist?(icon_source)
-
-    bundled_desktop = "#{staged_path}/1password-extracted/usr/share/applications/1password.desktop"
-    if File.exist?(bundled_desktop)
-      desktop_content = File.read(bundled_desktop)
-      desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/1password %U")
-      File.write("#{Dir.home}/.local/share/applications/1password.desktop", desktop_content)
-    else
-      File.write("#{Dir.home}/.local/share/applications/1password.desktop", <<~EOS)
-        [Desktop Entry]
-        Name=1Password
-        Comment=Password manager that keeps all passwords secure behind one password
-        GenericName=Password Manager
-        Exec=#{HOMEBREW_PREFIX}/bin/1password %U
-        Icon=1password
-        Type=Application
-        StartupNotify=true
-        StartupWMClass=1Password
-        Categories=Utility;Security;
-        Keywords=password;security;encryption;
-        MimeType=x-scheme-handler/onepassword;x-scheme-handler/onepassword4;x-scheme-handler/onepassword-ssh;
-      EOS
+  livecheck do
+    url "https://releases.1password.com/linux/stable/index.xml"
+    regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :xml do |xml, regex|
+      xml.get_elements("rss//channel//item//link").map { |item| item.text[regex, 1] }
     end
   end
 
-  uninstall_postflight do
-    # Remove desktop integration files created during installation
-    FileUtils.rm("#{Dir.home}/.local/share/applications/1password.desktop")
-    FileUtils.rm("#{Dir.home}/.local/share/icons/1password.png")
+  auto_updates true
+
+  binary "1password-#{version}.#{Utils.alternate_arch(arch)}/1password",
+         target: "1password"
+  binary "1password-#{version}.#{Utils.alternate_arch(arch)}/op-ssh-sign",
+         target: "op-ssh-sign"
+  artifact "1password-#{version}.#{Utils.alternate_arch(arch)}/resources/1password.desktop",
+           target: "#{Dir.home}/.local/share/applications/1password.desktop"
+  artifact "1password-#{version}.#{Utils.alternate_arch(arch)}/resources/icons/hicolor/256x256/apps/1password.png",
+           target: "#{Dir.home}/.local/share/icons/1password.png"
+
+  preflight do
+    Utils.replace_path_in_file("#{staged_path}/1password-#{version}.#{Utils.alternate_arch(arch)}/resources/1password.desktop",
+                               "Exec=/opt/1Password/1password",
+                               "Exec=#{HOMEBREW_PREFIX}/bin/1password")
   end
+
+  caveats "You will need to run `sudo install -Dm0644 #{staged_path}/1password-#{version}.#{Utils.alternate_arch(arch)}/com.1password.1Password.policy -t /etc/polkit-1/actions/;` to enable unlocking the 1Password app via your system password."
 
   zap trash: [
     "~/.cache/1password",


### PR DESCRIPTION
This moves it to use the 1password tar.gz releases, and livecheck using the RSS feed for releases. 

There is no ~/.local place to put polkit policies, so we need to instruct on how.