### PR TITLE
Bluefin Wallpapers cask

### DIFF
--- a/Casks/bluefin-wallpapers.rb
+++ b/Casks/bluefin-wallpapers.rb
@@ -1,0 +1,19 @@
+cask "bluefin-wallpapers" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/ublue-os/packages/archive/refs/heads/main.zip"
+  name "bluefin-wallpapers"
+  desc "Wallpapers for Bluefin"
+  homepage "https://github.com/ublue-os/packages/tree/main/packages/bluefin/wallpapers"
+
+  livecheck do
+    url "https://github.com/ublue-os/packages"
+    strategy :git
+  end
+
+  Dir.glob("#{staged_path}/packages-main/packages/bluefin/wallpapers/images/*").each do |file|
+    artifact file, target: "#{Dir.home}/.local/share/backgrounds/#{File.basename(file)}"
+  end
+
+end

--- a/Casks/bluefin-wallpapers.rb
+++ b/Casks/bluefin-wallpapers.rb
@@ -2,7 +2,7 @@ cask "bluefin-wallpapers" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/ublue-os/packages/archive/refs/heads/main.zip"
+  url "https://github.com/ublue-os/packages/archive/refs/heads/main.tar.gz"
   name "bluefin-wallpapers"
   desc "Wallpapers for Bluefin"
   homepage "https://github.com/ublue-os/packages/tree/main/packages/bluefin/wallpapers"
@@ -15,5 +15,4 @@ cask "bluefin-wallpapers" do
   Dir.glob("#{staged_path}/packages-main/packages/bluefin/wallpapers/images/*").each do |file|
     artifact file, target: "#{Dir.home}/.local/share/backgrounds/#{File.basename(file)}"
   end
-
 end


### PR DESCRIPTION
Installs all the bluefin wallpapers from the repo.

Formula would have been a bit smaller in disk space, but Formulas are really messy to put files outside of the homebrew directories.

Using a cask is less ideal, but cleaner.