### PR TITLE
feat: add aurora-wallpapers

### DIFF
--- a/Casks/aurora-wallpapers.rb
+++ b/Casks/aurora-wallpapers.rb
@@ -1,0 +1,20 @@
+cask "aurora-wallpapers" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/ublue-os/packages/archive/refs/heads/main.tar.gz"
+  name "aurora-wallpapers"
+  desc "Wallpapers for Aurora"
+  homepage "https://github.com/ublue-os/packages/tree/main/packages/aurora/wallpapers"
+
+  livecheck do
+    url "https://github.com/ublue-os/packages"
+    strategy :git
+  end
+
+  Dir.glob("#{staged_path}/packages-main/packages/aurora/wallpapers/images/aurora-wallpaper-*").each do |dir|
+    next if File.basename(dir) == "aurora-wallpaper-1"
+
+    artifact dir, target: "#{Dir.home}/.local/share/backgrounds/aurora/#{File.basename(dir)}"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ brew install --cask lm-studio-linux
 brew install --cask 1password-gui-linux
 brew install --cask framework-tool
 brew install --cask bluefin-wallpapers
+brew install --cask aurora-wallpapers
 ```
 ## Includes
 


### PR DESCRIPTION
fixes: https://github.com/ublue-os/homebrew-tap/issues/22

Skipping the AI one, and only put the art commissioned for aurora

<img width="1257" height="276" alt="image" src="https://github.com/user-attachments/assets/a10ca12c-8495-4b1e-aa65-3dc97858471d" />

they show up in the settings if you add `~/.local/share/backgrounds/aurora`

<img width="1344" height="575" alt="image" src="https://github.com/user-attachments/assets/4e4e387c-1ad6-4999-a576-c81b552641b9" />
