### PR TITLE
fix: add lm-studio-linux livecheck stanza

### DIFF
--- a/Casks/lm-studio-linux.rb
+++ b/Casks/lm-studio-linux.rb
@@ -7,6 +7,17 @@ cask "lm-studio-linux" do
   desc "Discover, download, and run local LLMs"
   homepage "https://lmstudio.ai/"
 
+  livecheck do
+    url "https://versions-prod.lmstudio.ai/update/linux/x86/#{version}"
+    strategy :json do |json|
+      version = json["version"]
+      build = json["build"]
+      next if version.blank? || build.blank?
+
+      "#{version}-#{build}"
+    end
+  end
+
   auto_updates true
   depends_on formula: "squashfs"
 


### PR DESCRIPTION
```
❯ brew livecheck --debug ublue-os/tap/lm-studio-linux

Cask:             lm-studio-linux
livecheck block?: Yes

URL:              https://versions-prod.lmstudio.ai/update/linux/x86/0.3.28-2
Strategy:         Json

Matched Versions:
0.3.28-2

lm-studio-linux: 0.3.28-2 ==> 0.3.28-2
```