### PR TITLE
Adjust brew bump workflow for GH actions environment

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
+
       - name: Configure git
         uses: Homebrew/actions/git-user-config@main
 


### PR DESCRIPTION
resolves https://github.com/ublue-os/homebrew-tap/issues/53
related PR https://github.com/ublue-os/homebrew-tap/pull/77

The workflow needed adjustments in order to be executed in the GitHub Actions environment. This PR fixes the previous issue but the recently added `Casks/1password-flatpak-browser-integration.rb` breaks the bump command since flatpak is required - seems like the error occurs during the 1password livecheck.

> Error: No such file or directory - flatpak
> Error: Process completed with exit code 1.

See my logs here for more details: https://github.com/lambdaclan/homebrew-tap/actions/runs/18438058790/job/52534308155