### PR TITLE
Fix brew bump action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 3,15 * * *" # daily at 03:00 and 15:00 UTC
-  push:
-    branches:
-      - fix-bump-action
 
 jobs:
   bump:


### PR DESCRIPTION
## Summary

This PR fixes the brew `bump` action caused by issues in the `1password-gui-linux` cask definition.

### Changes
1. Removed the top-level `module Utils`  
   - The module was being interpreted incorrectly by Homebrew, causing errors like:  
     `File name too long - /home/linuxbrew/.linuxbrew/Caskroom/module Utils`
     
     
<img width="1242" height="209" alt="image" src="https://github.com/user-attachments/assets/30112e1b-e6f1-42bf-a88f-7915e641b3e5" />


2. Replaced the `alternate_arch` method with a local variable (`arch_suffix`)  

3. Replaced `replace_path_in_file` helper with inline `File.read`/`File.write` logic  

4. Fixed `brew style` issues  
