### PR TITLE
fix: Update SHA256 checksums for 2025-11-30 releases

### DIFF
--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -23,7 +23,7 @@ cask "bluefin-wallpapers-extra" do
     end
   elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-gnome.tar.zstd"
-    sha256 "b5fdfd634d007ea9bb2f6c8aa8ad783593741814337adbd94039c16d6bc1cf0b"
+    sha256 "98b8a10a31f571a791f806a96d5f40287169d6fae223d5ae53dae065d377a4d6"
 
     Dir.glob("#{staged_path}/images/*").each do |file|
       folder = File.basename(file, File.extname(file)).gsub(/-night|-day/, "")

--- a/Casks/framework-wallpapers.rb
+++ b/Casks/framework-wallpapers.rb
@@ -23,7 +23,7 @@ cask "framework-wallpapers" do
     end
   elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
     url "https://github.com/ublue-os/artwork/releases/download/framework-v#{version}/framework-wallpapers-gnome.tar.zstd"
-    sha256 "b6666aeae2f5e2ac3248243d2ed04d823379abd70df39fc3e5550479b586724b"
+    sha256 "cec25556745ec15cbc73eeb356e94479d7daf9cfbcb1a56da408e1e3c917441b"
 
     Dir.glob("#{staged_path}/images/*").each do |file|
       artifact file, target: "#{destination_dir}/#{File.basename(file)}"


### PR DESCRIPTION
Fixes ublue-os/artwork#48

## Problem
The Homebrew casks for wallpaper packages were failing to upgrade due to SHA256 checksum mismatches on the 2025-11-30 release artifacts.

## Changes
Updated SHA256 checksums for GNOME variants:

### framework-wallpapers.rb
- **Old SHA256**: `b6666aeae2f5e2ac3248243d2ed04d823379abd70df39fc3e5550479b586724b`
- **New SHA256**: `cec25556745ec15cbc73eeb356e94479d7daf9cfbcb1a56da408e1e3c917441b`

### bluefin-wallpapers-extra.rb
- **Old SHA256**: `b5fdfd634d007ea9bb2f6c8aa8ad783593741814337adbd94039c16d6bc1cf0b`
- **New SHA256**: `98b8a10a31f571a791f806a96d5f40287169d6fae223d5ae53dae065d377a4d6`

## Verification
The checksums were verified by downloading the actual release artifacts from GitHub and calculating their SHA256 hashes:
- `framework-wallpapers-gnome.tar.zstd` from release `framework-v2025-11-30`
- `bluefin-wallpapers-extra-gnome.tar.zstd` from release `bluefin-extra-v2025-11-30`

This will fix the `brew upgrade` failures for users.