### PR TITLE
Fix wallpaper cask artifact purging issues

### DIFF
--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -17,36 +17,58 @@ cask "bluefin-wallpapers-extra" do
   if File.exist?("/usr/bin/plasmashell")
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-kde.tar.zstd"
     sha256 "84f714825d61a0518421314b1afb3b7fcb19c7f5c213a06f5f8928a15be54a1c"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
-    end
   elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-gnome.tar.zstd"
     sha256 "98b8a10a31f571a791f806a96d5f40287169d6fae223d5ae53dae065d377a4d6"
-
-    Dir.glob("#{staged_path}/images/*").each do |file|
-      folder = File.basename(file, File.extname(file)).gsub(/-night|-day/, "")
-      artifact file, target: "#{destination_dir}/#{folder}/#{File.basename(file)}"
-    end
-
-    Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-      artifact file, target: "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-    end
   else
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-png.tar.zstd"
     sha256 "e8c5b8fdfa2d4cc7614a6892ba0809215aa8e6273c501d2e18d2fcbe126b85e8"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-    end
   end
 
-  preflight do
+  postflight do
+    # Process XML files first
     Dir.glob("#{staged_path}/**/*.xml").each do |file|
       contents = File.read(file)
       contents.gsub!("~", Dir.home)
       File.write(file, contents)
+    end
+
+    if File.exist?("/usr/bin/plasmashell")
+      FileUtils.mkdir_p(kde_destination_dir)
+      Dir.glob("#{staged_path}/*").each do |file|
+        FileUtils.cp_r(file, "#{kde_destination_dir}/#{File.basename(file)}", remove_destination: true)
+      end
+    elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
+      FileUtils.mkdir_p("#{Dir.home}/.local/share/gnome-background-properties")
+
+      Dir.glob("#{staged_path}/images/*").each do |file|
+        folder = File.basename(file, File.extname(file)).gsub(/-night|-day/, "")
+        target_dir = "#{destination_dir}/#{folder}"
+        FileUtils.mkdir_p(target_dir)
+        FileUtils.cp(file, "#{target_dir}/#{File.basename(file)}")
+      end
+
+      Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
+        FileUtils.cp(file, "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}")
+      end
+    else
+      FileUtils.mkdir_p(destination_dir)
+      Dir.glob("#{staged_path}/*").each do |file|
+        FileUtils.cp_r(file, "#{destination_dir}/#{File.basename(file)}", remove_destination: true)
+      end
+    end
+  end
+
+  uninstall_postflight do
+    if File.exist?("/usr/bin/plasmashell")
+      FileUtils.rm_rf(kde_destination_dir) if File.exist?(kde_destination_dir)
+    else
+      FileUtils.rm_rf(destination_dir) if File.exist?(destination_dir)
+    end
+
+    gnome_props_dir = "#{Dir.home}/.local/share/gnome-background-properties"
+    Dir.glob("#{gnome_props_dir}/bluefin-extra-*.xml").each do |file|
+      FileUtils.rm(file) if File.exist?(file)
     end
   end
 end

--- a/Casks/bluefin-wallpapers.rb
+++ b/Casks/bluefin-wallpapers.rb
@@ -17,35 +17,56 @@ cask "bluefin-wallpapers" do
   if File.exist?("/usr/bin/plasmashell")
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-kde.tar.zstd"
     sha256 "d0c57affa270d6a8846f067341d69073c8469f8f97c2e60fbb7b51153483403e"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
-    end
   elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-gnome.tar.zstd"
     sha256 "b3aa0df9e6ba7380a797779e14ca58abd6c3d95a7e5e75f6e39a052494f792f1"
-
-    Dir.glob("#{staged_path}/images/*").each do |file|
-      artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-    end
-
-    Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-      artifact file, target: "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-    end
   else
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-png.tar.zstd"
     sha256 "078c2e259055ea220045e1aea84a13d7a7a68c5ab05dbcfe928501b0a98d625c"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-    end
   end
 
-  preflight do
+  postflight do
+    # Process XML files first
     Dir.glob("#{staged_path}/**/*.xml").each do |file|
       contents = File.read(file)
       contents.gsub!("~", Dir.home)
       File.write(file, contents)
+    end
+
+    if File.exist?("/usr/bin/plasmashell")
+      FileUtils.mkdir_p(kde_destination_dir)
+      Dir.glob("#{staged_path}/*").each do |file|
+        FileUtils.cp_r(file, "#{kde_destination_dir}/#{File.basename(file)}", remove_destination: true)
+      end
+    elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
+      FileUtils.mkdir_p(destination_dir)
+      FileUtils.mkdir_p("#{Dir.home}/.local/share/gnome-background-properties")
+
+      Dir.glob("#{staged_path}/images/*").each do |file|
+        FileUtils.cp(file, "#{destination_dir}/#{File.basename(file)}")
+      end
+
+      Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
+        FileUtils.cp(file, "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}")
+      end
+    else
+      FileUtils.mkdir_p(destination_dir)
+      Dir.glob("#{staged_path}/*").each do |file|
+        FileUtils.cp_r(file, "#{destination_dir}/#{File.basename(file)}", remove_destination: true)
+      end
+    end
+  end
+
+  uninstall_postflight do
+    if File.exist?("/usr/bin/plasmashell")
+      FileUtils.rm_rf(kde_destination_dir) if File.exist?(kde_destination_dir)
+    else
+      FileUtils.rm_rf(destination_dir) if File.exist?(destination_dir)
+    end
+
+    gnome_props_dir = "#{Dir.home}/.local/share/gnome-background-properties"
+    Dir.glob("#{gnome_props_dir}/bluefin-*.xml").each do |file|
+      FileUtils.rm(file) if File.exist?(file)
     end
   end
 end


### PR DESCRIPTION
## Problem
When running `brew upgrade`, wallpaper casks fail with:
```
Error: It seems there is already a Generic Artifact at '/home/linuxbrew/.linuxbrew/Caskroom/bazzite-wallpapers/2025-11-29/images/Bazzite_Giants.jpg'
```

## Root Cause
Dynamic `Dir.glob` loops with `artifact` stanzas prevent Homebrew from properly tracking files for cleanup during upgrades/reinstalls.

## Solution
Replace dynamic artifact declarations with:
- `postflight` blocks for file installation
- `uninstall_postflight` blocks for explicit cleanup
- Maintains identical file placement and XML processing logic

## Affected Casks
- bazzite-wallpapers
- aurora-wallpapers  
- bluefin-wallpapers
- bluefin-wallpapers-extra
- framework-wallpapers

## Testing
✅ `brew reinstall ublue-os/tap/bazzite-wallpapers` succeeds
✅ Files installed correctly to ~/.local/share/backgrounds/
✅ No artifact tracking errors