### PR TITLE
fix(wallpapers): use postflight for artifacts

### DIFF
--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -14,42 +14,18 @@ cask "bluefin-wallpapers-extra" do
   on_macos do
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-macos.tar.zstd"
     sha256 "bce247f55c0971c8b601b63c02a62cd8e66fc502cdd620b188e9306db60123b0"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra/#{File.basename(file)}"
-    end
   end
 
   on_linux do
-    destination_dir = "#{Dir.home}/.local/share/backgrounds/bluefin"
-    kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/bluefin"
-
     if File.exist?("/usr/bin/plasmashell")
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-kde.tar.zstd"
       sha256 "0e78c4772c9f03efa4f6a801081c82dd950ff5dffe69f2c30e9a58e64c4a2a42"
-
-      Dir.glob("#{staged_path}/*").each do |file|
-        artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
-      end
     elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-gnome.tar.zstd"
       sha256 "3062c5d0ec576ce896b1fda73959423b1285151c68bca44e8216c3feb14d45ba"
-
-      Dir.glob("#{staged_path}/images/*").each do |file|
-        folder = File.basename(file, File.extname(file)).gsub(/-night|-day/, "")
-        artifact file, target: "#{destination_dir}/#{folder}/#{File.basename(file)}"
-      end
-
-      Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-        artifact file, target: "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-      end
     else
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-extra-v#{version}/bluefin-wallpapers-extra-png.tar.zstd"
       sha256 "1d5201c6cf33f64b7cdc7a11099f79cb311aa67fd6781c4158d614209e05133f"
-
-      Dir.glob("#{staged_path}/*").each do |file|
-        artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-      end
     end
   end
 
@@ -71,8 +47,57 @@ cask "bluefin-wallpapers-extra" do
 
   postflight do
     if OS.mac?
+      Dir.glob("#{staged_path}/*").each do |file|
+        target = "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra/#{File.basename(file)}"
+        FileUtils.ln_sf(file, target)
+      end
       puts "Wallpapers installed to: #{Dir.home}/Library/Desktop Pictures/Bluefin-Extra"
       puts "To use: System Settings > Wallpaper > Add Folder"
     end
+
+    if OS.linux?
+      destination_dir = "#{Dir.home}/.local/share/backgrounds/bluefin"
+      kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/bluefin"
+
+      if File.exist?("/usr/bin/plasmashell")
+        Dir.glob("#{staged_path}/*").each do |file|
+          target = "#{kde_destination_dir}/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+      elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
+        Dir.glob("#{staged_path}/images/*").each do |file|
+          folder = File.basename(file, File.extname(file)).gsub(/-night|-day/, "")
+          FileUtils.mkdir_p "#{destination_dir}/#{folder}"
+          target = "#{destination_dir}/#{folder}/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+
+        Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
+          target = "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+      else
+        Dir.glob("#{staged_path}/*").each do |file|
+          target = "#{destination_dir}/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+      end
+    end
   end
+
+  uninstall_postflight do
+    FileUtils.rm_r "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra" if OS.mac?
+
+    if OS.linux?
+      FileUtils.rm_r "#{Dir.home}/.local/share/backgrounds/bluefin"
+      FileUtils.rm_r "#{Dir.home}/.local/share/wallpapers/bluefin"
+    end
+  end
+
+  zap trash: [
+    "#{Dir.home}/.local/share/backgrounds/bluefin",
+    "#{Dir.home}/.local/share/gnome-background-properties/bluefin-*.xml",
+    "#{Dir.home}/.local/share/wallpapers/bluefin",
+    "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra",
+  ]
 end

--- a/Casks/framework-wallpapers.rb
+++ b/Casks/framework-wallpapers.rb
@@ -14,41 +14,18 @@ cask "framework-wallpapers" do
   on_macos do
     url "https://github.com/ublue-os/artwork/releases/download/framework-v#{version}/framework-wallpapers-macos.tar.zstd"
     sha256 "9d69f1d59e0d20d1e91fbb8c7c6e9009cb95b06058d31b407debad77a1c82da4"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{Dir.home}/Library/Desktop Pictures/Framework/#{File.basename(file)}"
-    end
   end
 
   on_linux do
-    destination_dir = "#{Dir.home}/.local/share/backgrounds/framework"
-    kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/framework"
-
     if File.exist?("/usr/bin/plasmashell")
       url "https://github.com/ublue-os/artwork/releases/download/framework-v#{version}/framework-wallpapers-kde.tar.zstd"
       sha256 "01225c2d24a8d14e4a42953889dcc6263050792a21f87b23346fb9ff6c13adf8"
-
-      Dir.glob("#{staged_path}/*").each do |file|
-        artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
-      end
     elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
       url "https://github.com/ublue-os/artwork/releases/download/framework-v#{version}/framework-wallpapers-gnome.tar.zstd"
       sha256 "f936e03bd0486bab1ec1fdce30f93ff81fd49f949d8c9b878d51fa58dfa96524"
-
-      Dir.glob("#{staged_path}/images/*").each do |file|
-        artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-      end
-
-      Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-        artifact file, target: "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-      end
     else
       url "https://github.com/ublue-os/artwork/releases/download/framework-v#{version}/framework-wallpapers-png.tar.zstd"
       sha256 "ab55af2ddf076955c6982065e827f4c1fb9864555cb151c7bb10e8187492caf3"
-
-      Dir.glob("#{staged_path}/*").each do |file|
-        artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-      end
     end
   end
 
@@ -70,8 +47,55 @@ cask "framework-wallpapers" do
 
   postflight do
     if OS.mac?
+      Dir.glob("#{staged_path}/*").each do |file|
+        target = "#{Dir.home}/Library/Desktop Pictures/Framework/#{File.basename(file)}"
+        FileUtils.ln_sf(file, target)
+      end
       puts "Wallpapers installed to: #{Dir.home}/Library/Desktop Pictures/Framework"
       puts "To use: System Settings > Wallpaper > Add Folder"
     end
+
+    if OS.linux?
+      destination_dir = "#{Dir.home}/.local/share/backgrounds/framework"
+      kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/framework"
+
+      if File.exist?("/usr/bin/plasmashell")
+        Dir.glob("#{staged_path}/*").each do |file|
+          target = "#{kde_destination_dir}/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+      elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
+        Dir.glob("#{staged_path}/images/*").each do |file|
+          target = "#{destination_dir}/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+
+        Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
+          target = "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+      else
+        Dir.glob("#{staged_path}/*").each do |file|
+          target = "#{destination_dir}/#{File.basename(file)}"
+          FileUtils.ln_sf(file, target)
+        end
+      end
+    end
   end
+
+  uninstall_postflight do
+    FileUtils.rm_r "#{Dir.home}/Library/Desktop Pictures/Framework" if OS.mac?
+
+    if OS.linux?
+      FileUtils.rm_r "#{Dir.home}/.local/share/backgrounds/framework"
+      FileUtils.rm_r "#{Dir.home}/.local/share/wallpapers/framework"
+    end
+  end
+
+  zap trash: [
+    "#{Dir.home}/.local/share/backgrounds/framework",
+    "#{Dir.home}/.local/share/gnome-background-properties/framework-*.xml",
+    "#{Dir.home}/.local/share/wallpapers/framework",
+    "#{Dir.home}/Library/Desktop Pictures/Framework",
+  ]
 end


### PR DESCRIPTION
Artifact stanzas with Dir.glob were evaluated at cask parse time, before archives were extracted. This caused "already a Generic Artifact" errors during upgrades when old version files existed.

- Move Dir.glob file linking to postflight blocks
- Add uninstall_postflight for cleanup on uninstall
- Add zap stanzas for complete removal