### PR TITLE
Fix homebrew bump action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,6 +19,24 @@ jobs:
       - name: Configure git
         uses: Homebrew/actions/git-user-config@main
 
+      - name: Checkout homebrew-core
+        uses: actions/checkout@v6
+        with:
+          repository: Homebrew/homebrew-core
+          path: homebrew-core
+          fetch-depth: 1
+          sparse-checkout: |
+            Formula/
+
+      - name: Move homebrew-core to tap directory
+        run: |
+          BREW_REPO="$(brew --repo)"
+          CORE_TAP="$BREW_REPO/Library/Taps/homebrew/homebrew-core"
+
+          mkdir -p "$(dirname "$CORE_TAP")"
+          rm -rf "$CORE_TAP"
+          mv homebrew-core "$CORE_TAP"
+
       - name: Bump packages
         env:
           HOMEBREW_DEVELOPER: 1


### PR DESCRIPTION
## Issue description

> continuation from the old PR #192 which I had to close to re-test the PR creation

After more testing I have verified that simply changing the python version in pmbootstrap formula which currently depends on python@3.14 does not resolve the issue. I have tried multiple versions such as python@3.13 and more generic catch all types like python@3 and simply python.

As mentioned in the original PR, tapping homebrew-core before the bump fixes the issue but since that operation is quite slow I wanted to see if there is another way.

The new approach uses git directly via `checkout` instead of brew tap and enables a shallow and sparse checkout to only fetch the formula data. Based on my tests, this keeps the action runtime low and resolves the issue.
