### PR TITLE
docs(linux-mcp-server): add link to upstream survey

### DIFF
--- a/Formula/linux-mcp-server.rb
+++ b/Formula/linux-mcp-server.rb
@@ -549,8 +549,8 @@ class LinuxMcpServer < Formula
       For more configuration options, see:
         https://rhel-lightspeed.github.io/linux-mcp-server/clients/
 
-      Feedback:
-        https://example.com/feedback
+      Help us make this better for you! Feedback Appreciated:
+        https://tinyurl.com/linux-mcp-server
     EOS
   end
 


### PR DESCRIPTION
The l-m-s team is running a survey for user feedback, this adds it to the text output on installation.