### PR TITLE
fix: add git pull --rebase to bottle workflow to handle concurrent pushes

### DIFF
--- a/.github/workflows/bottle-linux-mcp-server.yml
+++ b/.github/workflows/bottle-linux-mcp-server.yml
@@ -1,0 +1,186 @@
+name: Build linux-mcp-server Bottles
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Formula/linux-mcp-server.rb'
+  workflow_dispatch:
+
+jobs:
+  get-version:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract version from formula
+        id: version
+        run: |
+          VERSION=$(grep -oE 'url ".*linux_mcp_server-[0-9]+\.[0-9]+\.[0-9]+' Formula/linux-mcp-server.rb | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+  bottle-macos:
+    needs: get-version
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Build bottle
+        run: |
+          VERSION="${{ needs.get-version.outputs.version }}"
+          brew install --build-bottle 'ublue-os/tap/linux-mcp-server'
+          brew bottle --json --no-rebuild --root-url="https://github.com/${{ github.repository }}/releases/download/linux-mcp-server-${VERSION}" 'ublue-os/tap/linux-mcp-server'
+
+      - name: Rename bottle files
+        run: |
+          for file in *.bottle.*; do
+            if [[ -f "$file" ]]; then
+              newname="${file/--/-}"
+              if [[ "$file" != "$newname" ]]; then
+                mv "$file" "$newname"
+              fi
+            fi
+          done
+
+      - name: Upload bottle artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: bottle-macos
+          path: '*.bottle.*'
+
+  bottle-linux:
+    needs: get-version
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build bottle in Docker
+        run: |
+          VERSION="${{ needs.get-version.outputs.version }}"
+
+          mkdir -p /tmp/homebrew-tap
+          cp -r . /tmp/homebrew-tap/
+
+          docker run --rm \
+            -v "/tmp/homebrew-tap:/tmp/homebrew-tap" \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            homebrew/ubuntu24.04:latest \
+            bash -c "
+              brew update-reset
+              mkdir -p /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ublue-os
+              cp -r /tmp/homebrew-tap /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ublue-os/homebrew-tap
+
+              brew install --build-bottle 'ublue-os/tap/linux-mcp-server'
+
+              cd /tmp
+              brew bottle --json --no-rebuild --root-url='https://github.com/${{ github.repository }}/releases/download/linux-mcp-server-${VERSION}' 'ublue-os/tap/linux-mcp-server'
+
+              sudo chown -R \$(id -u):\$(id -g) /workspace
+              cp *.bottle.* /workspace/
+            "
+
+      - name: Rename bottle files
+        run: |
+          sudo chown -R "$(whoami)" .
+          for file in *.bottle.*; do
+            if [[ -f "$file" ]]; then
+              newname="${file/--/-}"
+              if [[ "$file" != "$newname" ]]; then
+                mv "$file" "$newname"
+              fi
+            fi
+          done
+
+      - name: Upload bottle artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: bottle-linux
+          path: '*.bottle.*'
+
+  upload:
+    needs: [get-version, bottle-macos, bottle-linux]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download all bottles
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: bottle-*
+          merge-multiple: true
+          path: /tmp/bottles
+
+      - name: Check if release exists
+        id: check-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.get-version.outputs.version }}"
+          if gh release view "linux-mcp-server-$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release-exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create new release
+        if: steps.check-release.outputs.release-exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.get-version.outputs.version }}"
+          gh release create "linux-mcp-server-$VERSION" /tmp/bottles/*.bottle.* \
+            --title "linux-mcp-server $VERSION bottles" \
+            --notes "Bottles for linux-mcp-server $VERSION" \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Update existing release
+        if: steps.check-release.outputs.release-exists == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.get-version.outputs.version }}"
+          gh release upload "linux-mcp-server-$VERSION" /tmp/bottles/*.bottle.* \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update formula with bottle SHAs
+        run: |
+          if [ -d /tmp/bottles ] && ls /tmp/bottles/*.bottle.json 1> /dev/null 2>&1; then
+            cd /tmp/bottles
+            brew bottle --merge --write --no-commit ./*.bottle.json
+
+            cp "$(brew --repository)/Library/Taps/ublue-os/homebrew-tap/Formula/linux-mcp-server.rb" /tmp/linux-mcp-server.rb
+            cp /tmp/linux-mcp-server.rb "${{ github.workspace }}/Formula/"
+          else
+            echo "No bottle files found, skipping merge"
+          fi
+
+      - name: Commit bottle updates
+        run: |
+          if git diff --quiet Formula/linux-mcp-server.rb; then
+            echo "No changes to formula"
+          else
+            git config user.email "action@github.com"
+            git config user.name "GitHub Action"
+            git add Formula/linux-mcp-server.rb
+            git commit -m "chore: add linux-mcp-server bottles for ${{ needs.get-version.outputs.version }}"
+            git pull --rebase origin main
+            git push origin main
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-15 ]
+        os: [ ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read


### PR DESCRIPTION
## Problem

The upload job in the `bottle-linux-mcp-server.yml` workflow fails when other PRs are merged during the ~30min bottle build, advancing `main` past the checked-out commit ([example failure](https://github.com/ublue-os/homebrew-tap/actions/runs/21893824030)).

## What changed

Added `git pull --rebase origin main` before `git push` in the bottle workflow's commit step, so it picks up any commits that landed on `main` during the build.

## What we tried first

Attempted to replace the dedicated bottle workflow with `pr-pull` by adding `macos-15` to the `tests.yml` matrix. This didn't work because `brew test-bot --only-tap-syntax` validates all casks against the host OS, causing Linux-only casks (1password-gui-linux, vscodium-linux, etc.) to fail on macOS. A conditional OS matrix (`detect-os` job) was explored but added too much complexity for the benefit.