### PR TITLE
feat: add visual-studio-code-linux@insiders cask

### DIFF
--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -1,0 +1,75 @@
+cask "visual-studio-code-linux@insiders" do
+  arch arm: "arm64", intel: "x64"
+  os linux: "linux"
+
+  version "1.116.0-insider"
+  sha256 arm64_linux:  "1e53507fd94fd3416d4ce16486669bc9580063833f3285f46e84a6cfb35df1d6",
+         x86_64_linux: "ca96532594217d5c8753ff9eadb605ac53e222662faea973be81fb612c724120"
+
+  url "https://update.code.visualstudio.com/#{version}/#{os}-#{arch}/insider"
+  name "Microsoft Visual Studio Code Insiders"
+  name "VS Code Insiders"
+  desc "Open-source code editor (Insiders build)"
+  homepage "https://code.visualstudio.com/insiders/"
+
+  livecheck do
+    url "https://update.code.visualstudio.com/api/update/#{os}-#{arch}/insider/latest"
+    strategy :json do |json|
+      json["productVersion"]
+    end
+  end
+
+  binary "VSCode-linux-#{arch}/bin/code-insiders"
+  binary "VSCode-linux-#{arch}/bin/code-tunnel-insiders"
+  bash_completion "#{staged_path}/VSCode-linux-#{arch}/resources/completions/bash/code-insiders"
+  zsh_completion  "#{staged_path}/VSCode-linux-#{arch}/resources/completions/zsh/_code-insiders"
+  artifact "VSCode-linux-#{arch}/code-insiders.desktop",
+           target: "#{Dir.home}/.local/share/applications/code-insiders.desktop"
+  artifact "VSCode-linux-#{arch}/code-insiders-url-handler.desktop",
+           target: "#{Dir.home}/.local/share/applications/code-insiders-url-handler.desktop"
+  artifact "VSCode-linux-#{arch}/resources/app/resources/linux/code.png",
+           target: "#{Dir.home}/.local/share/icons/vscode-insiders.png"
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    File.write("#{staged_path}/VSCode-linux-#{arch}/code-insiders.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=Visual Studio Code - Insiders
+      Comment=Code Editing. Redefined.
+      GenericName=Text Editor
+      Exec=#{HOMEBREW_PREFIX}/bin/code-insiders %F
+      Icon=#{Dir.home}/.local/share/icons/vscode-insiders.png
+      Type=Application
+      StartupNotify=false
+      StartupWMClass=Code - Insiders
+      Categories=TextEditor;Development;IDE;
+      MimeType=application/x-code-workspace;
+      Actions=new-empty-window;
+      Keywords=vscode;
+
+      [Desktop Action new-empty-window]
+      Name=New Empty Window
+      Exec=#{HOMEBREW_PREFIX}/bin/code-insiders --new-window %F
+      Icon=#{Dir.home}/.local/share/icons/vscode-insiders.png
+    EOS
+    File.write("#{staged_path}/VSCode-linux-#{arch}/code-insiders-url-handler.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=Visual Studio Code Insiders - URL Handler
+      Comment=Code Editing. Redefined.
+      GenericName=Text Editor
+      Exec=#{HOMEBREW_PREFIX}/bin/code-insiders --open-url %U
+      Icon=#{Dir.home}/.local/share/icons/vscode-insiders.png
+      Type=Application
+      NoDisplay=true
+      StartupNotify=true
+      Categories=Utility;TextEditor;Development;IDE;
+      MimeType=x-scheme-handler/vscode-insiders;
+      Keywords=vscode;
+    EOS
+  end
+
+  zap trash: [
+    "~/.config/Code - Insiders",
+    "~/.vscode-insiders",
+  ]
+end


### PR DESCRIPTION
Closes #336

## Summary

- Adds `visual-studio-code-linux@insiders` cask for Linux (x64 and arm64)
- Follows the exact same pattern as `visual-studio-code-linux.rb`
- Installs side-by-side with stable (`code-insiders` binary, separate config dirs)

## Details

| Field | Value |
|---|---|
| Download URL | `https://update.code.visualstudio.com/#{version}/#{os}-#{arch}/insider` |
| Livecheck | JSON from update API, `productVersion` field |
| Binaries | `code-insiders`, `code-tunnel-insiders` |
| Completions | bash + zsh |
| Desktop entries | generated via `preflight` (same as stable) |
| Zap | `~/.config/Code - Insiders`, `~/.vscode-insiders` |

## Test plan

- [ ] `brew install --cask visual-studio-code-linux@insiders` installs successfully on x64
- [ ] `code-insiders --version` returns the expected version
- [ ] Desktop entry appears in application launcher
- [ ] `brew livecheck --cask visual-studio-code-linux@insiders` returns current version
- [ ] Runs side-by-side with stable `visual-studio-code-linux` without conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)