### PR TITLE
set_permissions to make zpass.sh executable

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -99,6 +99,7 @@ cask "1password-gui-linux" do
       #!/bin/bash
       zenity --password --title="Homebrew Sudo Password Prompt"
     EOS
+    set_permissions("#{staged_path}/zpass.sh", "755")
 
     # 1Password browser support binary needs to be owned by group onepassword and
     # have the GID bit set in order to function


### PR DESCRIPTION
`uupd` runs `brew update` + `brew upgrade`, but these automatic updates run unattended, with no chance for the user to enter a sudo password as required by `1password-uninstall.sh`.

It looks like `zpass.sh` and  `SUDO_ASKPASS` in `1password-uninstall.sh` are working to collect the sudo password in these cases. Currently `zpass.sh` is not executable, though, and I believe it needs to be in order for this plan to work.

This is causing the `uupd` update to fail when a new version of `1password-gui-linux` is released.

See e.g. `ls -l /var/home/linuxbrew/.linuxbrew/Caskroom/1password-gui-linux/8.12.10/zpass.sh`
and
`SUDO_ASKPASS=/var/home/linuxbrew/.linuxbrew/Caskroom/1password-gui-linux/8.12.10/zpass.sh sudo -A ls`