### PR TITLE
fix(bluefin-wallpapers): fix disappearing wallpapers

### DIFF
--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -89,8 +89,27 @@ cask "bluefin-wallpapers-extra" do
     FileUtils.rm_r "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra" if OS.mac?
 
     if OS.linux?
-      FileUtils.rm_r "#{Dir.home}/.local/share/backgrounds/bluefin"
-      FileUtils.rm_r "#{Dir.home}/.local/share/wallpapers/bluefin"
+      bg_dir    = "#{Dir.home}/.local/share/backgrounds/bluefin"
+      kde_dir   = "#{Dir.home}/.local/share/wallpapers/bluefin"
+      props_dir = "#{Dir.home}/.local/share/gnome-background-properties"
+
+      # Remove only the symlinks this cask created via postflight. During upgrade,
+      # these point to the old staged path (now being removed) and become broken.
+      # Symlinks from bluefin-wallpapers point to a separate Caskroom path that is
+      # not being removed, so they remain valid and are intentionally left alone.
+      [bg_dir, kde_dir].each do |dir|
+        next unless Dir.exist?(dir)
+        Dir.glob("#{dir}/**/*").sort.reverse.each do |f|
+          File.unlink(f) if File.symlink?(f) && !File.exist?(f)
+          Dir.rmdir(f) rescue nil if File.directory?(f) && Dir.empty?(f)
+        end
+      end
+
+      if Dir.exist?(props_dir)
+        Dir.glob("#{props_dir}/*.xml").each do |f|
+          File.unlink(f) if File.symlink?(f) && !File.exist?(f)
+        end
+      end
     end
   end
 

--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -102,12 +102,13 @@ cask "bluefin-wallpapers-extra" do
 
         Dir.glob("#{dir}/**/*").reverse_each do |f|
           File.unlink(f) if File.symlink?(f) && !File.exist?(f)
-          if File.directory?(f) && Dir.empty?(f)
-            begin
-              Dir.rmdir(f)
-            rescue StandardError
-              nil
-            end
+          next unless File.directory?(f)
+          next unless Dir.empty?(f)
+
+          begin
+            Dir.rmdir(f)
+          rescue
+            nil
           end
         end
       end

--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -99,9 +99,16 @@ cask "bluefin-wallpapers-extra" do
       # not being removed, so they remain valid and are intentionally left alone.
       [bg_dir, kde_dir].each do |dir|
         next unless Dir.exist?(dir)
-        Dir.glob("#{dir}/**/*").sort.reverse.each do |f|
+
+        Dir.glob("#{dir}/**/*").reverse_each do |f|
           File.unlink(f) if File.symlink?(f) && !File.exist?(f)
-          Dir.rmdir(f) rescue nil if File.directory?(f) && Dir.empty?(f)
+          if File.directory?(f) && Dir.empty?(f)
+            begin
+              Dir.rmdir(f)
+            rescue StandardError
+              nil
+            end
+          end
         end
       end
 

--- a/Casks/bluefin-wallpapers.rb
+++ b/Casks/bluefin-wallpapers.rb
@@ -1,5 +1,5 @@
 cask "bluefin-wallpapers" do
-  version "2025-12-14"
+  version "2026-04-13"
 
   name "bluefin-wallpapers"
   desc "Wallpapers for Bluefin"
@@ -13,7 +13,7 @@ cask "bluefin-wallpapers" do
 
   on_macos do
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-macos.tar.zstd"
-    sha256 "2d6c6673a21e27e6683ffc1c00b6995c68e9ee2af8700a84a9624f7b655cf9fa"
+    sha256 "7d067bd998717e318aff98732cc3f35e6909d59e8191543962dc72bd8ba9fc80"
 
     Dir.glob("#{staged_path}/*").each do |file|
       artifact file, target: "#{Dir.home}/Library/Desktop Pictures/Bluefin/#{File.basename(file)}"
@@ -26,16 +26,16 @@ cask "bluefin-wallpapers" do
 
     if File.exist?("/usr/bin/plasmashell")
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-kde.tar.zstd"
-      sha256 "9450ef9c2b406522fbc0823aebe3915508b103bf081852fd3cbc85a1abe3753a"
+      sha256 "efbeeae6b04043a086088f71ec1dad0e63ba1c56fae440d69a9b459b03b5ffc1"
 
       Dir.glob("#{staged_path}/*").each do |file|
         artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
       end
     elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-gnome.tar.zstd"
-      sha256 "5c243462d74bf4a1fa60659972f2fdf45fd16b226bd2d4f7c2d27701176d5eb6"
+      sha256 "87fdc6505da615e5df902df408371d5ab34efef6199144925324a564e6801e00"
 
-      Dir.glob("#{staged_path}/images/*").each do |file|
+      Dir.glob("#{staged_path}/*").select { |f| File.file?(f) }.each do |file|
         artifact file, target: "#{destination_dir}/#{File.basename(file)}"
       end
 
@@ -44,7 +44,7 @@ cask "bluefin-wallpapers" do
       end
     else
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-png.tar.zstd"
-      sha256 "1a15439aab464b3aa5380370863648e079f3421d96969499eed877077a865727"
+      sha256 "15ea697d0cf97aabe5d9aaac5585104ff0dfea8690c10b37e8f888b771019065"
 
       Dir.glob("#{staged_path}/*").each do |file|
         artifact file, target: "#{destination_dir}/#{File.basename(file)}"


### PR DESCRIPTION
Wallpapers were disappearing for people not on bluefin (since those are on the image) so you have to be on a non-bluefin to notice this: 

Fixes: https://github.com/ublue-os/homebrew-tap/issues/350

Agent notes:

bluefin-wallpapers.rb:
- Fix GNOME artifact glob: s/images\/*/\.select { File.file? }/ — the gnome tarball has .jxl and transition .xml files at the archive root, not under images/. The broken glob was introduced in 1bf7e37 (Nov 2025) when per-type tarballs were adopted; the glob was never updated to match the new layout. Every GNOME install since Nov 29 2025 silently dropped all wallpaper images and transition XMLs from ~/.local/share/backgrounds/bluefin.
- Bump to 2026-04-13 with updated sha256 for all four variants.

bluefin-wallpapers-extra.rb:
- Fix uninstall_postflight: replace FileUtils.rm_r on the shared backgrounds/bluefin directory with surgical broken-symlink removal. The old rm_r nuked the entire shared directory on every upgrade, destroying files installed by bluefin-wallpapers (and any manual user additions). The new code removes only symlinks that point to the now-deleted old staged path; artifact symlinks from bluefin-wallpapers point to a separate Caskroom path and survive. Full directory removal is still available via brew uninstall --zap.




Assisted-by: Claude Sonnet 4.6 via GitHub Copilot