### PR TITLE
fix(wallpapers): add os stanza so brew bundle installs casks on linux

### DIFF
--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -1,4 +1,6 @@
 cask "bluefin-wallpapers-extra" do
+  os macos: "darwin", linux: "linux"
+
   version "2026-04-13"
 
   name "bluefin-wallpapers-extra"

--- a/Casks/bluefin-wallpapers.rb
+++ b/Casks/bluefin-wallpapers.rb
@@ -1,4 +1,6 @@
 cask "bluefin-wallpapers" do
+  os macos: "darwin", linux: "linux"
+
   version "2026-04-13"
 
   name "bluefin-wallpapers"

--- a/Casks/framework-wallpapers.rb
+++ b/Casks/framework-wallpapers.rb
@@ -1,4 +1,6 @@
 cask "framework-wallpapers" do
+  os macos: "darwin", linux: "linux"
+
   version "2025-12-14"
 
   name "framework-wallpapers"


### PR DESCRIPTION
`brew bundle` on Linux was skipping `bluefin-wallpapers`, `bluefin-wallpapers-extra`, and `framework-wallpapers` with "requires macOS" because Homebrew's `Cask#supports_linux?` returns false for casks that use `on_macos`/`on_linux` blocks without an explicit `os` stanza. This adds `os macos: "darwin", linux: "linux"` to the three affected casks. Direct `brew install --cask` was unaffected, only the Brewfile path used by `ujust bbrew`.

Fixes projectbluefin/common#297