### PR TITLE
fix(vscode): disable built-in update checks for brew installs

### DIFF
--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -32,6 +32,12 @@ cask "visual-studio-code-linux" do
            target: "#{Dir.home}/.local/share/applications/code-url-handler.desktop"
 
   preflight do
+    # Disable VS Code's built-in update checks; Homebrew manages this install.
+    product_json = "#{staged_path}/VSCode-linux-#{arch}/resources/app/product.json"
+    product = JSON.parse(File.read(product_json))
+    product.delete("updateUrl")
+    File.write(product_json, JSON.pretty_generate(product))
+
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
     File.write("#{staged_path}/VSCode-linux-#{arch}/code.desktop", <<~EOS)
       [Desktop Entry]

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -32,6 +32,12 @@ cask "visual-studio-code-linux@insiders" do
            target: "#{Dir.home}/.local/share/applications/code-insiders-url-handler.desktop"
 
   preflight do
+    # Disable VS Code's built-in update checks; Homebrew manages this install.
+    product_json = "#{staged_path}/VSCode-linux-#{arch}/resources/app/product.json"
+    product = JSON.parse(File.read(product_json))
+    product.delete("updateUrl")
+    File.write(product_json, JSON.pretty_generate(product))
+
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
     File.write("#{staged_path}/VSCode-linux-#{arch}/code-insiders.desktop", <<~EOS)
       [Desktop Entry]


### PR DESCRIPTION
Fixes ublue-os/homebrew-tap#399.