### PR TITLE
Update antigravity-linux IDE cask to v2.0.1

### DIFF
--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -16,7 +16,7 @@ cask "antigravity-linux" do
   homepage "https://antigravity.google/"
 
   livecheck do
-    url "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/linux-x64/stable/latest"
+    url "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/linux-x64/stable/latest"
     regex(%r{/stable/([^/]+)/}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)
@@ -32,6 +32,9 @@ cask "antigravity-linux" do
            target: "#{Dir.home}/.local/share/applications/antigravity-url-handler.desktop"
   artifact "antigravity.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
+
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy"
 
   preflight do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
@@ -86,8 +89,11 @@ cask "antigravity-linux" do
 
   zap trash: [
     "~/.antigravity",
+    "~/.antigravity-ide",
+    "~/.antigravity-ide-server",
     "~/.config/Antigravity",
     "~/.config/antigravity",
+    "~/.gemini/antigravity-ide",
   ]
 
   caveats <<~EOS

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -34,6 +34,7 @@ cask "antigravity-linux" do
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "antigravity-ide"
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy-ide"
 
   preflight do

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -50,7 +50,7 @@ cask "antigravity-linux" do
       Name=Antigravity
       Comment=AI Coding Agent IDE
       GenericName=Text Editor
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" %F
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity-ide" %F
       Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
       Type=Application
       StartupNotify=false
@@ -62,7 +62,7 @@ cask "antigravity-linux" do
 
       [Desktop Action new-empty-window]
       Name=New Empty Window
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --new-window %F
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity-ide" --new-window %F
       Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
     EOS
 
@@ -71,7 +71,7 @@ cask "antigravity-linux" do
       Name=Antigravity - URL Handler
       Comment=AI Coding Agent IDE
       GenericName=Text Editor
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --open-url "%U"
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity-ide" --open-url "%U"
       Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
       Type=Application
       NoDisplay=true

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -33,7 +33,6 @@ cask "antigravity-linux" do
   artifact "antigravity.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
-  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "antigravity-ide"
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy-ide"
 

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -34,7 +34,7 @@ cask "antigravity-linux" do
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
-  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy"
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy-ide"
 
   preflight do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -2,14 +2,14 @@ cask "antigravity-linux" do
   arch arm: "arm", intel: "x64"
   os linux: "linux"
 
-  version "1.23.2,4781536860569600"
+  version "2.0.1,4861014005645312"
 
   on_linux do
-    sha256 arm64_linux:  "64d11085f17edc691adbe8952d59887f257d58448705dc2a19dfa23890d36df1",
-           x86_64_linux: "5232a4048ff4fa15685d9a981ba4fba573e297f3efc9b76f638e794baf775725"
+    sha256 arm64_linux:  "38e9cc0beb7d7782e0e7b2410e50945d56d66391a79989de391b9ba544a2697e",
+           x86_64_linux: "747163aa3a8afba4b316f97c40b4a75ca4736a59768a416cd1e881e73ec31ef9"
   end
 
-  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity.tar.gz",
+  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity%20IDE.tar.gz",
       verified: "edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/"
   name "Google Antigravity"
   desc "AI Coding Agent IDE"
@@ -26,10 +26,6 @@ cask "antigravity-linux" do
     end
   end
 
-  binary "#{staged_path}/Antigravity/bin/antigravity"
-  binary "#{staged_path}/Antigravity/bin/antigravity", target: "agy"
-  bash_completion "#{staged_path}/Antigravity/resources/completions/bash/antigravity"
-  zsh_completion  "#{staged_path}/Antigravity/resources/completions/zsh/_antigravity"
   artifact "antigravity.desktop",
            target: "#{Dir.home}/.local/share/applications/antigravity.desktop"
   artifact "antigravity-url-handler.desktop",
@@ -42,7 +38,7 @@ cask "antigravity-linux" do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
 
     # Copy icon from extracted archive
-    icon_path = "Antigravity/resources/app/out/vs/workbench/contrib/antigravityCustomAppIcon"
+    icon_path = "Antigravity IDE/resources/app/out/vs/workbench/contrib/antigravityCustomAppIcon"
     icon_source = "#{staged_path}/#{icon_path}/browser/media/antigravity/antigravity.png"
     FileUtils.cp icon_source, "#{staged_path}/antigravity.png" if File.exist?(icon_source)
 


### PR DESCRIPTION
Updates the existing antigravity-linux cask from v1.23.2 to v2.0.1 with the new Antigravity IDE release.