### PR TITLE
feat: update Antigravity IDE to 2.0.1 and add Antigravity CLI

### DIFF
--- a/Casks/antigravity-cli-linux.rb
+++ b/Casks/antigravity-cli-linux.rb
@@ -1,0 +1,41 @@
+cask "antigravity-cli-linux" do
+  arch arm: "arm", intel: "x64"
+  os linux: "linux"
+
+  version "1.0.0,5288553236791296"
+
+  on_linux do
+    sha256 arm64_linux:  "f4dc7c96c1836b00768d8a6ec6eacc7851f3424bd6f4ebe4d8b848a652072a85",
+           x86_64_linux: "70096340574fafc4a06c4d3c8057314e22d475ce1c820d0ad51ff07fb7e99eb6"
+  end
+
+  url "https://storage.googleapis.com/antigravity-public/antigravity-cli/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/cli_linux_#{arch == "arm" ? "arm64" : "x64"}.tar.gz",
+      verified: "storage.googleapis.com/antigravity-public/antigravity-cli/"
+  name "Antigravity CLI"
+  desc "AI Coding Agent CLI (successor to Gemini CLI)"
+  homepage "https://antigravity.google/cli"
+
+  livecheck do
+    url "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json"
+    strategy :json do |json|
+      version = json["version"]
+      match = json["url"]&.match(%r{/([\d.]+-(\d+))/})
+      next if match.blank?
+
+      "#{version},#{match[2]}"
+    end
+  end
+
+  binary "antigravity"
+  binary "antigravity", target: "agy"
+
+  zap trash: [
+    "~/.gemini/antigravity-cli",
+    "~/.antigravity-cli",
+  ]
+
+  caveats <<~EOS
+    Antigravity CLI is the new agent-first development tool from Google, replacing Gemini CLI.
+    It is recommended to use this alongside the Antigravity IDE (antigravity-linux).
+  EOS
+end

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -16,7 +16,7 @@ cask "antigravity-linux" do
   homepage "https://antigravity.google/"
 
   livecheck do
-    url "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/linux-x64/stable/latest"
+    url "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/linux-x64/stable/latest"
     regex(%r{/stable/([^/]+)/}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)
@@ -32,6 +32,9 @@ cask "antigravity-linux" do
            target: "#{Dir.home}/.local/share/applications/antigravity-url-handler.desktop"
   artifact "antigravity.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
+
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy"
 
   preflight do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
@@ -86,8 +89,11 @@ cask "antigravity-linux" do
 
   zap trash: [
     "~/.antigravity",
+    "~/.antigravity-ide",
+    "~/.antigravity-ide-server",
     "~/.config/Antigravity",
     "~/.config/antigravity",
+    "~/.gemini/antigravity-ide",
   ]
 
   caveats <<~EOS

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -34,6 +34,7 @@ cask "antigravity-linux" do
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "antigravity-ide"
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy-ide"
 
   preflight do

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -50,7 +50,7 @@ cask "antigravity-linux" do
       Name=Antigravity
       Comment=AI Coding Agent IDE
       GenericName=Text Editor
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" %F
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity-ide" %F
       Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
       Type=Application
       StartupNotify=false
@@ -62,7 +62,7 @@ cask "antigravity-linux" do
 
       [Desktop Action new-empty-window]
       Name=New Empty Window
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --new-window %F
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity-ide" --new-window %F
       Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
     EOS
 
@@ -71,7 +71,7 @@ cask "antigravity-linux" do
       Name=Antigravity - URL Handler
       Comment=AI Coding Agent IDE
       GenericName=Text Editor
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --open-url "%U"
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity-ide" --open-url "%U"
       Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
       Type=Application
       NoDisplay=true

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -33,7 +33,6 @@ cask "antigravity-linux" do
   artifact "antigravity.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
-  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "antigravity-ide"
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy-ide"
 

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -34,7 +34,7 @@ cask "antigravity-linux" do
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
   binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity"
-  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy"
+  binary "#{staged_path}/Antigravity IDE/resources/app/bin/antigravity", target: "agy-ide"
 
   preflight do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -2,14 +2,14 @@ cask "antigravity-linux" do
   arch arm: "arm", intel: "x64"
   os linux: "linux"
 
-  version "1.23.2,4781536860569600"
+  version "2.0.1,4861014005645312"
 
   on_linux do
-    sha256 arm64_linux:  "64d11085f17edc691adbe8952d59887f257d58448705dc2a19dfa23890d36df1",
-           x86_64_linux: "5232a4048ff4fa15685d9a981ba4fba573e297f3efc9b76f638e794baf775725"
+    sha256 arm64_linux:  "38e9cc0beb7d7782e0e7b2410e50945d56d66391a79989de391b9ba544a2697e",
+           x86_64_linux: "747163aa3a8afba4b316f97c40b4a75ca4736a59768a416cd1e881e73ec31ef9"
   end
 
-  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity.tar.gz",
+  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity%20IDE.tar.gz",
       verified: "edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/"
   name "Google Antigravity"
   desc "AI Coding Agent IDE"
@@ -26,10 +26,6 @@ cask "antigravity-linux" do
     end
   end
 
-  binary "#{staged_path}/Antigravity/bin/antigravity"
-  binary "#{staged_path}/Antigravity/bin/antigravity", target: "agy"
-  bash_completion "#{staged_path}/Antigravity/resources/completions/bash/antigravity"
-  zsh_completion  "#{staged_path}/Antigravity/resources/completions/zsh/_antigravity"
   artifact "antigravity.desktop",
            target: "#{Dir.home}/.local/share/applications/antigravity.desktop"
   artifact "antigravity-url-handler.desktop",
@@ -42,7 +38,7 @@ cask "antigravity-linux" do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
 
     # Copy icon from extracted archive
-    icon_path = "Antigravity/resources/app/out/vs/workbench/contrib/antigravityCustomAppIcon"
+    icon_path = "Antigravity IDE/resources/app/out/vs/workbench/contrib/antigravityCustomAppIcon"
     icon_source = "#{staged_path}/#{icon_path}/browser/media/antigravity/antigravity.png"
     FileUtils.cp icon_source, "#{staged_path}/antigravity.png" if File.exist?(icon_source)
 


### PR DESCRIPTION
This PR updates the Antigravity IDE to v2.0.1 (incorporating and building upon #409) and introduces the new Antigravity CLI (agy) as a separate cask (`antigravity-cli-linux`).

This alignment follows the transition from Gemini CLI to Antigravity CLI announced at Google I/O 2026. 

Key changes:
- Updated `antigravity-linux` (IDE) to 2.0.1 with new asset URLs and structure.
- Added `antigravity-cli-linux` (agy) v1.0.0.
- Updated binaries and zap paths to match the new product branding.

Ref: https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/