### PR TITLE
fix(vscode): fix brew bump by using explicit linux string in URLs

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -15,7 +15,7 @@ cask "1password-gui-linux" do
     when "x86_64" then "x64"
     end
 
-  url "https://downloads.1password.com/#{os}/tar/stable/#{arch}/1password-#{version}.#{arch_suffix}.tar.gz"
+  url "https://downloads.1password.com/linux/tar/stable/#{arch}/1password-#{version}.#{arch_suffix}.tar.gz"
   name "1Password"
   desc "Password manager that keeps all passwords secure behind one password"
   homepage "https://1password.com/"

--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -9,14 +9,14 @@ cask "visual-studio-code-linux" do
            x86_64_linux: "1dc648446074cbc53986ec5737d8cdae1303d098e69fe40d514eb410719db97a"
   end
 
-  url "https://update.code.visualstudio.com/#{version}/#{os}-#{arch}/stable"
+  url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/stable"
   name "Microsoft Visual Studio Code"
   name "VS Code"
   desc "Open-source code editor"
   homepage "https://code.visualstudio.com/"
 
   livecheck do
-    url "https://update.code.visualstudio.com/api/update/#{os}-#{arch}/stable/latest"
+    url "https://update.code.visualstudio.com/api/update/linux-#{arch}/stable/latest"
     strategy :json do |json|
       json["productVersion"]
     end

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -2,21 +2,21 @@ cask "visual-studio-code-linux@insiders" do
   arch arm: "arm64", intel: "x64"
   os linux: "linux"
 
-  version "1.120.0-insider"
+  version "1.121.0-insider"
 
   on_linux do
-    sha256 arm64_linux:  "ffa98de20b7ba09167c0d428a22b9a45b4d2ded60c07a8392df9f798d428bc6a",
-           x86_64_linux: "c9342d4e33b67b6f4a070c6ca1c8cf2ba77a0f29784a5727c9991429d1599545"
+    sha256 arm64_linux:  "07ce668fe51ace22bfdedd63277c4d32b340d60c9135e1e9a5e12124bd92d7f2",
+           x86_64_linux: "be5d508e6e4ba90f42756b475c651e45b199917ea5e505ecf08b650c876bcd24"
   end
 
-  url "https://update.code.visualstudio.com/#{version}/#{os}-#{arch}/insider"
+  url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/insider"
   name "Microsoft Visual Studio Code Insiders"
   name "VS Code Insiders"
   desc "Open-source code editor (Insiders build)"
   homepage "https://code.visualstudio.com/insiders/"
 
   livecheck do
-    url "https://update.code.visualstudio.com/api/update/#{os}-#{arch}/insider/latest"
+    url "https://update.code.visualstudio.com/api/update/linux-#{arch}/insider/latest"
     strategy :json do |json|
       json["productVersion"]
     end


### PR DESCRIPTION
The use of `#{os}` in the URL and livecheck blocks causes `brew bump` to fail with 404 errors during automated updates. 

In the context of the GitHub Actions runner, the `os` method doesn't reliably return 'linux', resulting in invalid URLs like `/-x64/stable`. Hardcoding 'linux' (as seen in other casks like vscodium) ensures the automation can download the file and update checksums correctly.

Fixes the 404 errors in Homebrew Bump workflows.