### PR TITLE
fix(casks): manual sync for latest versions (round 2)

### DIFF
--- a/Casks/antigravity-cli-linux.rb
+++ b/Casks/antigravity-cli-linux.rb
@@ -4,11 +4,11 @@ cask "antigravity-cli-linux" do
   livecheck_arch = on_arch_conditional arm: "arm64", intel: "amd64"
   os linux: "linux"
 
-  version "1.0.2,6109799369277440"
+  version "1.0.3,6260531212976128"
 
   on_linux do
-    sha256 arm64_linux:  "ca5aa7021ffda694b26f1a792ac965b053dd2ce426ce621b76d938df39675dfc",
-           x86_64_linux: "f6c7ca80d5099333bf229676473bd111e0daa6a0d8db7c532adf6503b0eaadc9"
+    sha256 arm64_linux:  "27aec1dd6270dd4acc6ffee425d8d7f28a89688d7c01191fd5e80ce6dfeb8ded",
+           x86_64_linux: "047d3635d97b4aeecc0dc33bf527d8411179d1544303003e89fc3cb83b0d0462"
   end
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-cli/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/cli_linux_#{file_arch}.tar.gz",

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -3,11 +3,11 @@ cask "antigravity-linux" do
   livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
   os linux: "linux"
 
-  version "2.0.1,6566078776737792"
+  version "2.0.10,5119448496078848"
 
   on_linux do
-    sha256 arm64_linux:  "5af56cc9dda954f369a61045b7da2f348bcb0b3507d272b4c0e9aa7cd6175d9b",
-           x86_64_linux: "0727e1f56961b6d2347941f278da69cc6c17de3befe988524848cd167380e9ab"
+    sha256 arm64_linux:  "31c07e3a6cbe968679d3717fa0bf27d70af88685db47ac12d79ce10035b69cab",
+           x86_64_linux: "12da60ba43aea31288b5ec64d89aab70f61fdb2a20c0cb5b610c20e83b646e32"
   end
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity.tar.gz",

--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -2,11 +2,11 @@ cask "visual-studio-code-linux" do
   arch arm: "arm64", intel: "x64"
   os linux: "linux"
 
-  version "1.121.0"
+  version "1.122.1"
 
   on_linux do
-    sha256 arm64_linux:  "c4bc2db051759a4a7229b68b7126ba3a797f87d3ea922373a307059102c61b85",
-           x86_64_linux: "8cf24cc41441453e11e8fe1ae9e58d32970e23dced399835c4b0904263d66820"
+    sha256 arm64_linux:  "f2c61a9c8d76a8330f8151bb4b440a2c4914d22fd2202909e70cff3b084ffa2e",
+           x86_64_linux: "b76e983771395da489ee0922f279b4ea1561e19bd70c453beccef8f59aea7c0a"
   end
 
   url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/stable"

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -2,11 +2,11 @@ cask "visual-studio-code-linux@insiders" do
   arch arm: "arm64", intel: "x64"
   os linux: "linux"
 
-  version "1.122.0-insider"
+  version "1.123.0-insider"
 
   on_linux do
-    sha256 arm64_linux:  "ea46705a724c188d0f6b061bcc8744faa9a5543c6b3e774071e1e0f58e772e7c",
-           x86_64_linux: "fdd2b80475dc7176740a46c64309575a317bf9b753326029385121324b0571d2"
+    sha256 arm64_linux:  "1b215283dca2233cf1c4886f9686683057578a03d885f6de36792df1405345d9",
+           x86_64_linux: "5ff563244686b3fd5d0cd7ba0cb8db1c2736000523eeec32da1d33139fd58773"
   end
 
   url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/insider"

--- a/Formula/pmbootstrap.rb
+++ b/Formula/pmbootstrap.rb
@@ -3,7 +3,7 @@ class Pmbootstrap < Formula
 
   desc "Sophisticated chroot / build / flash tool to develop and install postmarketOS"
   homepage "https://gitlab.postmarketos.org/postmarketOS/pmbootstrap"
-  url "https://gitlab.postmarketos.org/postmarketOS/pmbootstrap.git", tag: "3.10.2", revision: "021ed2f5e15fa70f1543997fc76c7e9f8b8c8e68"
+  url "https://gitlab.postmarketos.org/postmarketOS/pmbootstrap.git", tag: "3.10.3", revision: "845cda033ab534f8350f71baea9226603f1c5693"
 
   license "GPL-3.0-only"
 
@@ -13,11 +13,6 @@ class Pmbootstrap < Formula
     strategy :git do |tags, regex|
       tags.filter_map { |tag| tag[regex, 1] }
     end
-  end
-
-  bottle do
-    root_url "https://github.com/ublue-os/homebrew-tap/releases/download/pmbootstrap-3.10.2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "708d9f0d7c3ea4976688f5b3997eae32c6c30bafb1e46c3914a2f74c52be5f46"
   end
 
   depends_on linux: :any


### PR DESCRIPTION
This PR is the second round of manual syncs to clear the `Homebrew Bump` automated queue.

### ⚠️ The Automation Trap

As identified in Issue #418, the standard `brew bump` command cannot automatically update casks with multi-architecture `on_linux` stanzas. Every time Google or Microsoft releases an update, the bot will fail until these hashes are manually synchronized.

**Updates in this PR:**
- `antigravity-cli-linux` -> 1.0.3
- `antigravity-linux` (Core) -> 2.0.10
- `visual-studio-code-linux` -> 1.122.1
- `visual-studio-code-linux@insiders` -> 1.123.0-insider
- `pmbootstrap` -> 3.10.3 (Clearing the conflicting automated branch)

**Technical Audit:**
- `1password-gui-linux` is currently up to date (8.12.21).
- `vscodium-linux` is currently up to date (1.121.03429).
- `antigravity-ide-linux` is currently up to date (2.0.3).

**Recommendation:**
To escape this manual cycle, we should consider a custom Python bumper script (similar to wallpapers) that handles the `on_linux` block logic natively.