### PR TITLE
fix(casks): revert arch-conditional sha256 in on_linux block, as breaks brew bump

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -4,10 +4,9 @@ cask "1password-gui-linux" do
 
   version "8.12.21"
 
-  on_linux do
-    sha256 arm64_linux:  "58f154a8a29f75a77317b06d47d8149b44a562ae19377e9e2027c6b0fc62ac7d",
-           x86_64_linux: "27088c8b68a8ccfea3592214b605e56bce9a48086e5286fbb27aad51b7973e92"
-  end
+  sha256 arm64_linux:  "58f154a8a29f75a77317b06d47d8149b44a562ae19377e9e2027c6b0fc62ac7d",
+         x86_64_linux: "27088c8b68a8ccfea3592214b605e56bce9a48086e5286fbb27aad51b7973e92"
+  
 
   arch_suffix =
     case arch

--- a/Casks/antigravity-cli-linux.rb
+++ b/Casks/antigravity-cli-linux.rb
@@ -6,10 +6,8 @@ cask "antigravity-cli-linux" do
 
   version "1.0.2,6109799369277440"
 
-  on_linux do
-    sha256 arm64_linux:  "ca5aa7021ffda694b26f1a792ac965b053dd2ce426ce621b76d938df39675dfc",
-           x86_64_linux: "f6c7ca80d5099333bf229676473bd111e0daa6a0d8db7c532adf6503b0eaadc9"
-  end
+  sha256 arm64_linux:  "ca5aa7021ffda694b26f1a792ac965b053dd2ce426ce621b76d938df39675dfc",
+         x86_64_linux: "f6c7ca80d5099333bf229676473bd111e0daa6a0d8db7c532adf6503b0eaadc9"
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-cli/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/cli_linux_#{file_arch}.tar.gz",
       verified: "storage.googleapis.com/antigravity-public/antigravity-cli/"

--- a/Casks/antigravity-ide-linux.rb
+++ b/Casks/antigravity-ide-linux.rb
@@ -5,10 +5,8 @@ cask "antigravity-ide-linux" do
 
   version "2.0.3,6242596486512640"
 
-  on_linux do
-    sha256 arm64_linux:  "8ba7073c71f43c625fbfb95bd0b0c5c7d854974d5b4cc90f6e0fff4a109259ba",
-           x86_64_linux: "00b5fd709fef02c9f81ab4edd77e8d5baf8b85842cc654fa016d7d0492cde803"
-  end
+  sha256 arm64_linux:  "8ba7073c71f43c625fbfb95bd0b0c5c7d854974d5b4cc90f6e0fff4a109259ba",
+         x86_64_linux: "00b5fd709fef02c9f81ab4edd77e8d5baf8b85842cc654fa016d7d0492cde803"
 
   url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity%20IDE.tar.gz",
       verified: "edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/"

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -5,10 +5,8 @@ cask "antigravity-linux" do
 
   version "2.0.1,6566078776737792"
 
-  on_linux do
-    sha256 arm64_linux:  "5af56cc9dda954f369a61045b7da2f348bcb0b3507d272b4c0e9aa7cd6175d9b",
-           x86_64_linux: "0727e1f56961b6d2347941f278da69cc6c17de3befe988524848cd167380e9ab"
-  end
+  sha256 arm64_linux:  "5af56cc9dda954f369a61045b7da2f348bcb0b3507d272b4c0e9aa7cd6175d9b",
+         x86_64_linux: "0727e1f56961b6d2347941f278da69cc6c17de3befe988524848cd167380e9ab"
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity.tar.gz",
       verified: "storage.googleapis.com/antigravity-public/antigravity-hub/"

--- a/Casks/asusctl-linux.rb
+++ b/Casks/asusctl-linux.rb
@@ -4,10 +4,9 @@ cask "asusctl-linux" do
 
   version "6.3.7,2"
 
-  on_linux do
-    sha256 arm64_linux:  "1f77ef14fc4e24d8a67dbeedcf328cc443e5066854af5939f0f3c070f87af900",
-           x86_64_linux: "95467dfaa2225529773cc5020eb8d4c82392ab55c2dec01458cd4d67289001bd"
-  end
+  sha256 arm64_linux:  "1f77ef14fc4e24d8a67dbeedcf328cc443e5066854af5939f0f3c070f87af900",
+         x86_64_linux: "95467dfaa2225529773cc5020eb8d4c82392ab55c2dec01458cd4d67289001bd"
+
 
   release_tag = "asusctl-#{version.csv.first}-#{version.csv.second}"
   release_root = "asusctl-#{version.csv.first}-ubuntu-22.04-#{arch}"

--- a/Casks/rog-control-center-linux.rb
+++ b/Casks/rog-control-center-linux.rb
@@ -4,10 +4,8 @@ cask "rog-control-center-linux" do
 
   version "6.3.7,2"
 
-  on_linux do
-    sha256 arm64_linux:  "1f77ef14fc4e24d8a67dbeedcf328cc443e5066854af5939f0f3c070f87af900",
-           x86_64_linux: "95467dfaa2225529773cc5020eb8d4c82392ab55c2dec01458cd4d67289001bd"
-  end
+  sha256 arm64_linux:  "1f77ef14fc4e24d8a67dbeedcf328cc443e5066854af5939f0f3c070f87af900",
+         x86_64_linux: "95467dfaa2225529773cc5020eb8d4c82392ab55c2dec01458cd4d67289001bd"
 
   release_tag = "asusctl-#{version.csv.first}-#{version.csv.second}"
   release_root = "asusctl-#{version.csv.first}-ubuntu-22.04-#{arch}"

--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -4,10 +4,8 @@ cask "visual-studio-code-linux" do
 
   version "1.121.0"
 
-  on_linux do
-    sha256 arm64_linux:  "c4bc2db051759a4a7229b68b7126ba3a797f87d3ea922373a307059102c61b85",
-           x86_64_linux: "8cf24cc41441453e11e8fe1ae9e58d32970e23dced399835c4b0904263d66820"
-  end
+  sha256 arm64_linux:  "c4bc2db051759a4a7229b68b7126ba3a797f87d3ea922373a307059102c61b85",
+         x86_64_linux: "8cf24cc41441453e11e8fe1ae9e58d32970e23dced399835c4b0904263d66820"
 
   url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/stable"
   name "Microsoft Visual Studio Code"

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -4,10 +4,8 @@ cask "visual-studio-code-linux@insiders" do
 
   version "1.122.0-insider"
 
-  on_linux do
-    sha256 arm64_linux:  "ea46705a724c188d0f6b061bcc8744faa9a5543c6b3e774071e1e0f58e772e7c",
-           x86_64_linux: "fdd2b80475dc7176740a46c64309575a317bf9b753326029385121324b0571d2"
-  end
+  sha256 arm64_linux:  "ea46705a724c188d0f6b061bcc8744faa9a5543c6b3e774071e1e0f58e772e7c",
+         x86_64_linux: "fdd2b80475dc7176740a46c64309575a317bf9b753326029385121324b0571d2"
 
   url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/insider"
   name "Microsoft Visual Studio Code Insiders"

--- a/Casks/vscodium-linux.rb
+++ b/Casks/vscodium-linux.rb
@@ -4,10 +4,8 @@ cask "vscodium-linux" do
 
   version "1.121.03429"
 
-  on_linux do
-    sha256 arm64_linux:  "993e5dbf0f06399d069d968a452fd30334031046033a0723eb0ea534bcb9910d",
-           x86_64_linux: "2c9b06735d4c1face570935f4968d358f9f6269f5d9237813d0b825c7d70a143"
-  end
+  sha256 arm64_linux:  "993e5dbf0f06399d069d968a452fd30334031046033a0723eb0ea534bcb9910d",
+         x86_64_linux: "2c9b06735d4c1face570935f4968d358f9f6269f5d9237813d0b825c7d70a143"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-#{arch}-#{version}.tar.gz"
   name "VSCodium"


### PR DESCRIPTION
Reverts https://github.com/ublue-os/homebrew-tap/pull/394 - the arch-conditional sha256 in on_linux block, as breaks brew bump like [any of the recent bump runs](https://github.com/ublue-os/homebrew-tap/actions/runs/26769101277)


Example of bumps working pre-commit: 

<img width="1430" height="1653" alt="image" src="https://github.com/user-attachments/assets/714be7e0-5527-463f-b44f-dba72f4b51af" />

Bump job is currently failing:

<img width="1107" height="1233" alt="image" src="https://github.com/user-attachments/assets/a5c0824e-9157-4624-9468-29fc8284a8b5" />