### PR TITLE
fix(cask): vsc-insiders versioning and vscodium linting

### DIFF
--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -2,11 +2,11 @@ cask "visual-studio-code-linux@insiders" do
   arch arm: "arm64", intel: "x64"
   os linux: "linux"
 
-  version "1.126.0-insider"
-  sha256 arm64_linux:  "0cec6147c33c17b3fd4167a9741cf8962d092b61cf843da44d3c9395ba10bf10",
-         x86_64_linux: "9431ee95eb5fbc54bf7816fe89dc00468376003466ce5597b8478199b7373f8e"
+  version "1.126.0-insider,79d34e6e519a89e97d70cc6714337f58accd3ed2"
+  sha256 arm64_linux:  "90d0b5e08cc5abf0e5d0686d66be4145d8b845c1cb2db64e8593ccad366213f3",
+         x86_64_linux: "d7d68506962ac0711176231ffd368015f9db50e97c7ce36dc9c26066a95f6aba"
 
-  url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/insider"
+  url "https://update.code.visualstudio.com/#{version.csv.first}/linux-#{arch}/insider"
   name "Microsoft Visual Studio Code Insiders"
   name "VS Code Insiders"
   desc "Open-source code editor (Insiders build)"
@@ -15,7 +15,11 @@ cask "visual-studio-code-linux@insiders" do
   livecheck do
     url "https://update.code.visualstudio.com/api/update/linux-#{arch}/insider/latest"
     strategy :json do |json|
-      json["productVersion"]
+      version = json["productVersion"]
+      build = json["version"]
+      next if version.blank? || build.blank?
+
+      "#{version},#{build}"
     end
   end
 

--- a/Casks/vscodium-linux.rb
+++ b/Casks/vscodium-linux.rb
@@ -3,7 +3,6 @@ cask "vscodium-linux" do
   os linux: "linux"
 
   version "1.121.03429"
-
   sha256 arm64_linux:  "993e5dbf0f06399d069d968a452fd30334031046033a0723eb0ea534bcb9910d",
          x86_64_linux: "2c9b06735d4c1face570935f4968d358f9f6269f5d9237813d0b825c7d70a143"
 


### PR DESCRIPTION
## Problem

`visual-studio-code-linux@insiders` has been experiencing `checksum mismatch` errors because Microsoft silently rebuilds the Insiders binary under the same product version tag (e.g. `1.126.0-insider`) with a different commit. The automated `brew bump` workflow only detects product version changes, so it ignores these rebuilds — leaving the cask with a stale sha256.

**Live proof:** PR #464 (auto-generated bump to `1.126.0-insider`) was merged with sha256 `9431ee...`, but Microsoft then rebuilt that same version. Users now see:

```
Error: Cask reports different checksum:     9431ee95eb5fbc54bf7816fe89dc00468376003466ce5597b8478199b7373f8e
       SHA-256 checksum of downloaded file: d7d68506962ac0711176231ffd368015f9db50e97c7ce36dc9c26066a95f6aba
```

Closes #442.

---

## Fix

### 1. CSV versioning (`productVersion,commitHash`)

The version string now tracks **both** the product version and the build's commit hash:

```
1.126.0-insider,79d34e6e519a89e97d70cc6714337f58accd3ed2
```

The enhanced livecheck extracts both fields from the Microsoft update JSON:

```ruby
livecheck do
  url "https://update.code.visualstudio.com/api/update/linux-#{arch}/insider/latest"
  strategy :json do |json|
    version = json["productVersion"]
    build   = json["version"]          # commit hash
    next if version.blank? || build.blank?
    "#{version},#{build}"
  end
end
```

This means `brew bump` will now trigger on **every binary rebuild**, not just version bumps.

### 2. Stable download URL using `version.csv.first`

The download URL now uses only the product version part of the CSV, preserving the original URL pattern:

```ruby
url "https://update.code.visualstudio.com/#{version.csv.first}/linux-#{arch}/insider"
```

The initial PR draft used the `/api/update/.../latest` endpoint as the download URL, which would have been mutable (always the newest build) and not serve a binary archive directly. Using `version.csv.first` keeps the URL stable and identical in structure to what the cask used before.

### 3. Updated sha256 (post-rebuild values)

Both checksums updated to match the current `79d34e6e...` build:

| Arch       | sha256 |
|------------|--------|
| `arm64`    | `90d0b5e08cc5abf0e5d0686d66be4145d8b845c1cb2db64e8593ccad366213f3` |
| `x86_64`   | `d7d68506962ac0711176231ffd368015f9db50e97c7ce36dc9c26066a95f6aba` |

### 4. vscodium-linux linting fix

Removed a stray blank line between `version` and `sha256` to pass `brew style` (`Cask/StanzaGrouping`).

---

## Remaining edge case

The product-version download URL (`https://update.code.visualstudio.com/#{version.csv.first}/linux-#{arch}/insider`) is technically mutable — Microsoft can replace the binary while keeping the same version. However, livecheck now detects commit changes and triggers a bump, so the window is limited to the delay between a rebuild and the next automated bump run. Fully eliminating the race would require per-arch CDN URLs with build timestamps, which is a larger change and would need discussion.