### PR TITLE
Add Zed Linux cask

### DIFF
--- a/Casks/zed-linux.rb
+++ b/Casks/zed-linux.rb
@@ -1,0 +1,45 @@
+cask "zed-linux" do
+  version "1.14.2"
+  sha256 "6c476103b49a87dc62c46b8cc4dca84c0458ed53537de664ebdbc99b47daee2d"
+
+  url "https://github.com/zed-industries/zed/releases/download/v#{version}/zed-linux-x86_64.tar.gz"
+  name "Zed"
+  desc "High-performance, multiplayer code editor"
+  homepage "https://zed.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "zed.app/bin/zed"
+
+  preflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.mkdir_p "#{xdg_data}/applications"
+    FileUtils.mkdir_p "#{xdg_data}/icons"
+  end
+
+  postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    desktop_content = File.read("#{staged_path}/zed.app/share/applications/dev.zed.Zed.desktop")
+    desktop_content.gsub!(/^TryExec=.*/, "TryExec=#{HOMEBREW_PREFIX}/bin/zed")
+    desktop_content.gsub!(/^Exec=zed/, "Exec=#{HOMEBREW_PREFIX}/bin/zed")
+    desktop_content.gsub!(/^Icon=.*/, "Icon=zed")
+    File.write("#{xdg_data}/applications/dev.zed.Zed.desktop", desktop_content)
+    FileUtils.cp("#{staged_path}/zed.app/share/icons/hicolor/512x512/apps/zed.png",
+                 "#{xdg_data}/icons/zed.png")
+  end
+
+  uninstall_postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.rm("#{xdg_data}/applications/dev.zed.Zed.desktop")
+    FileUtils.rm("#{xdg_data}/icons/zed.png")
+  end
+
+  zap trash: [
+    "#{ENV.fetch("XDG_CACHE_HOME", "#{Dir.home}/.cache")}/zed",
+    "#{ENV.fetch("XDG_CONFIG_HOME", "#{Dir.home}/.config")}/zed",
+    "#{ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")}/zed",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ brew install --cask antigravity-ide-linux
 brew install --cask antigravity-cli-linux
 brew install --cask asusctl-linux
 brew install --cask rog-control-center-linux
+brew install --cask zed-linux
 
 brew install --cask bluefin-wallpapers
 brew install --cask bluefin-wallpapers-extra
@@ -57,6 +58,7 @@ brew install --cask framework-wallpapers
 - VSCodium - Open-source build of VS Code
 - Framework System Tool - Hardware management for Framework laptops
 - rog control center - GUI frontend for asusctl (for Asus ROG etc laptops)
+- Zed - High-performance, multiplayer code editor
 
 ### Wallpapers
 


### PR DESCRIPTION
Promotes the stable Zed Linux cask from the experimental tap into the production tap.
The preview cask remains in ublue-os/homebrew-experimental-tap.