### PR TITLE
Add 1password-cli-linux cask

### DIFF
--- a/Casks/1password-cli-linux.rb
+++ b/Casks/1password-cli-linux.rb
@@ -1,0 +1,54 @@
+cask "1password-cli-linux" do
+  arch intel: "amd64", arm: "arm64"
+  os linux: "linux"
+
+  version "2.35.0"
+  sha256 arm64_linux:  "28153b3e1b379cc117a2b8478fc29c73e4a391d0a9b7876c360d305e98390a78",
+         x86_64_linux: "4457ade59850b852c64c77164235b34dd0b984ef7826eb0ccd32f1fd78a2ceb7"
+
+  url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_linux_#{arch}_v#{version}.zip",
+      verified: "cache.agilebits.com/dist/1P/op2/pkg/"
+  name "1Password CLI"
+  desc "Command-line interface for 1Password"
+  homepage "https://developer.1password.com/docs/cli"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/check/1/0/CLI2/en/0/N"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  conflicts_with cask: "1password-cli"
+
+  binary "op"
+
+  generate_completions_from_executable "op", "completion"
+
+  postflight do
+    # For the 1Password desktop app integration to trust the CLI, the op
+    # binary must be owned by root:onepassword-cli with the setgid bit set.
+    # The deb/rpm packages set this up in their post-install scripts; since
+    # this cask installs from the zip, it has to do the same. Running this
+    # in postflight also re-applies the permissions on every upgrade.
+    # https://developer.1password.com/docs/cli/app-integration/
+    system <<~EOS
+      #!/bin/bash
+      if [ ! "$(getent group onepassword-cli)" ]; then
+        echo "Creating group 'onepassword-cli' for the 1Password desktop app integration, you may be prompted for your password."
+        sudo groupadd onepassword-cli
+      fi
+    EOS
+    set_ownership("#{staged_path}/op", user: "root", group: "onepassword-cli")
+    # can't use set_permissions here because we no longer own the file and brew tries to run chmod without sudo
+    system "sudo", "chmod", "2755", "#{File.expand_path(staged_path)}/op"
+  end
+
+  uninstall_preflight do
+    # re-take ownership of the binary so brew can remove it without sudo
+    system "sudo", "chown", "#{ENV.fetch("USER", nil)}:#{ENV.fetch("USER", nil)}",
+           "#{File.expand_path(staged_path)}/op"
+  end
+
+  zap trash: "~/.config/op"
+end


### PR DESCRIPTION
## Summary

Adds a `1password-cli-linux` cask that installs the 1Password CLI from the official zip **and** sets up the permissions the desktop app requires to trust the CLI:

- creates the `onepassword-cli` group (mirroring the official deb/rpm post-install scripts)
- applies `root:onepassword-cli` ownership + setgid (`2755`) on the `op` binary in `postflight`

This addresses the CLI portion of #208: installing `op` from the `homebrew/cask` `1password-cli` cask leaves the binary as `$USER:$USER`, which makes the desktop app integration fail with `response: unsupportedClientType`. Even after fixing permissions manually, every `brew upgrade` silently resets them. Because this cask applies the permissions in `postflight`, they are re-applied automatically on every install/upgrade — same pattern `1password-gui-linux` already uses for `1Password-BrowserSupport`.

Also includes an `uninstall_preflight` that re-takes ownership of the binary so brew can remove it without issues, `conflicts_with` the upstream `1password-cli` cask, and a `livecheck` block compatible with the tap's bump workflow.

## Testing

On Bluefin `44.20260714` (x86_64):

- `brew style` — no offenses
- `brew audit --cask --online ublue-os/tap/1password-cli-linux` — clean
- `brew livecheck` — resolves `2.35.0 ==> 2.35.0`
- The permission setup itself is verified working on my machine (manually applied, exactly what postflight does): `op signin` / `op vault list` work through the desktop app integration with polkit/fingerprint auth, where they previously failed with `unsupportedClientType`

sha256 values match the ones in the `homebrew/cask` `1password-cli` cask for the Linux artifacts.

Assisted-by: claude-fable-5 via OpenCode
