### PR TITLE
Fix sha256 Linux Casks evaluation

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -3,7 +3,9 @@ cask "1password-gui-linux" do
   os linux: "linux"
 
   version "8.12.24"
-  sha256 arm64_linux:  "11b75ecefe1d65c4f7d37e617fd3d0b26d5a86724b5e9c5059ce2f55c52f8d18",
+  sha256 arm:          "11b75ecefe1d65c4f7d37e617fd3d0b26d5a86724b5e9c5059ce2f55c52f8d18",
+         intel:        "5f3c52d5f2eea80d60c5d76b313a1ea8efcc235453dace67b5a3d0dedaf189e2",
+         arm64_linux:  "11b75ecefe1d65c4f7d37e617fd3d0b26d5a86724b5e9c5059ce2f55c52f8d18",
          x86_64_linux: "5f3c52d5f2eea80d60c5d76b313a1ea8efcc235453dace67b5a3d0dedaf189e2"
 
   arch_suffix =

--- a/Casks/antigravity-cli-linux.rb
+++ b/Casks/antigravity-cli-linux.rb
@@ -5,7 +5,9 @@ cask "antigravity-cli-linux" do
   os linux: "linux"
 
   version "1.0.9,6003845613092864"
-  sha256 arm64_linux:  "944d67056b7cc6e4411dca84d9f077b1e460c8cd2a4432d2cdf219421ff73e5a",
+  sha256 arm:          "944d67056b7cc6e4411dca84d9f077b1e460c8cd2a4432d2cdf219421ff73e5a",
+         intel:        "cd80f85f43b52b389d7b498d6784f8316d57a9cc62eae23d840c5de368f9c4d5",
+         arm64_linux:  "944d67056b7cc6e4411dca84d9f077b1e460c8cd2a4432d2cdf219421ff73e5a",
          x86_64_linux: "cd80f85f43b52b389d7b498d6784f8316d57a9cc62eae23d840c5de368f9c4d5"
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-cli/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/cli_linux_#{file_arch}.tar.gz",

--- a/Casks/antigravity-ide-linux.rb
+++ b/Casks/antigravity-ide-linux.rb
@@ -4,7 +4,9 @@ cask "antigravity-ide-linux" do
   os linux: "linux"
 
   version "2.0.4,6381998290370560"
-  sha256 arm64_linux:  "30435204d14cdcd479b37fd9ae077425d7ab7bb90f99af2bc41638205e02fb37",
+  sha256 arm:          "30435204d14cdcd479b37fd9ae077425d7ab7bb90f99af2bc41638205e02fb37",
+         intel:        "66337d45f2472ce5e89f394e77aec74909aa1be0bb33c9f73299a95f458e6770",
+         arm64_linux:  "30435204d14cdcd479b37fd9ae077425d7ab7bb90f99af2bc41638205e02fb37",
          x86_64_linux: "66337d45f2472ce5e89f394e77aec74909aa1be0bb33c9f73299a95f458e6770"
 
   url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity%20IDE.tar.gz",

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -4,7 +4,9 @@ cask "antigravity-linux" do
   os linux: "linux"
 
   version "2.0.6,5413878570549248"
-  sha256 arm64_linux:  "02fc7f47650582ac72b845853b514de6c83ea7a4cd8a8d739e1a8688db2f45a9",
+  sha256 arm:          "02fc7f47650582ac72b845853b514de6c83ea7a4cd8a8d739e1a8688db2f45a9",
+         intel:        "ad1e04535149b07c27030eb1ead40f4efda388cb39020bcbb9accdfb49e44cc5",
+         arm64_linux:  "02fc7f47650582ac72b845853b514de6c83ea7a4cd8a8d739e1a8688db2f45a9",
          x86_64_linux: "ad1e04535149b07c27030eb1ead40f4efda388cb39020bcbb9accdfb49e44cc5"
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity.tar.gz",

--- a/Casks/asusctl-linux.rb
+++ b/Casks/asusctl-linux.rb
@@ -3,7 +3,9 @@ cask "asusctl-linux" do
   os linux: "linux"
 
   version "6.3.8,3"
-  sha256 arm64_linux:  "66b7e0c8c358ad2281c806240a410be1c0e61c3c182b05408490f92de779bb9d",
+  sha256 arm:          "66b7e0c8c358ad2281c806240a410be1c0e61c3c182b05408490f92de779bb9d",
+         intel:        "f05fbc48e5971649685d9269a4e7d6c835e3163e8946c4a3cebc49a5cc647cc5",
+         arm64_linux:  "66b7e0c8c358ad2281c806240a410be1c0e61c3c182b05408490f92de779bb9d",
          x86_64_linux: "f05fbc48e5971649685d9269a4e7d6c835e3163e8946c4a3cebc49a5cc647cc5"
 
   release_tag = "asusctl-#{version.csv.first}-#{version.csv.second}"

--- a/Casks/rog-control-center-linux.rb
+++ b/Casks/rog-control-center-linux.rb
@@ -3,7 +3,9 @@ cask "rog-control-center-linux" do
   os linux: "linux"
 
   version "6.3.8,3"
-  sha256 arm64_linux:  "66b7e0c8c358ad2281c806240a410be1c0e61c3c182b05408490f92de779bb9d",
+  sha256 arm:          "66b7e0c8c358ad2281c806240a410be1c0e61c3c182b05408490f92de779bb9d",
+         intel:        "f05fbc48e5971649685d9269a4e7d6c835e3163e8946c4a3cebc49a5cc647cc5",
+         arm64_linux:  "66b7e0c8c358ad2281c806240a410be1c0e61c3c182b05408490f92de779bb9d",
          x86_64_linux: "f05fbc48e5971649685d9269a4e7d6c835e3163e8946c4a3cebc49a5cc647cc5"
 
   release_tag = "asusctl-#{version.csv.first}-#{version.csv.second}"

--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -3,7 +3,9 @@ cask "visual-studio-code-linux" do
   os linux: "linux"
 
   version "1.125.0"
-  sha256 arm64_linux:  "00e1e6ad5a39436884e95fe71d19e24155df84370bedbcc129d5df7bca1914fd",
+  sha256 arm:          "00e1e6ad5a39436884e95fe71d19e24155df84370bedbcc129d5df7bca1914fd",
+         intel:        "4d3ba51e90a24f679acb6b5beded6e6f5eb8ae0b6d067077e82738255a317f4f",
+         arm64_linux:  "00e1e6ad5a39436884e95fe71d19e24155df84370bedbcc129d5df7bca1914fd",
          x86_64_linux: "4d3ba51e90a24f679acb6b5beded6e6f5eb8ae0b6d067077e82738255a317f4f"
 
   url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/stable"

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -3,7 +3,9 @@ cask "visual-studio-code-linux@insiders" do
   os linux: "linux"
 
   version "1.126.0-insider,79d34e6e519a89e97d70cc6714337f58accd3ed2"
-  sha256 arm64_linux:  "90d0b5e08cc5abf0e5d0686d66be4145d8b845c1cb2db64e8593ccad366213f3",
+  sha256 arm:          "90d0b5e08cc5abf0e5d0686d66be4145d8b845c1cb2db64e8593ccad366213f3",
+         intel:        "d7d68506962ac0711176231ffd368015f9db50e97c7ce36dc9c26066a95f6aba",
+         arm64_linux:  "90d0b5e08cc5abf0e5d0686d66be4145d8b845c1cb2db64e8593ccad366213f3",
          x86_64_linux: "d7d68506962ac0711176231ffd368015f9db50e97c7ce36dc9c26066a95f6aba"
 
   url "https://update.code.visualstudio.com/#{version.csv.first}/linux-#{arch}/insider"

--- a/Casks/vscodium-linux.rb
+++ b/Casks/vscodium-linux.rb
@@ -3,7 +3,9 @@ cask "vscodium-linux" do
   os linux: "linux"
 
   version "1.121.03429"
-  sha256 arm64_linux:  "993e5dbf0f06399d069d968a452fd30334031046033a0723eb0ea534bcb9910d",
+  sha256 arm:          "993e5dbf0f06399d069d968a452fd30334031046033a0723eb0ea534bcb9910d",
+         intel:        "2c9b06735d4c1face570935f4968d358f9f6269f5d9237813d0b825c7d70a143",
+         arm64_linux:  "993e5dbf0f06399d069d968a452fd30334031046033a0723eb0ea534bcb9910d",
          x86_64_linux: "2c9b06735d4c1face570935f4968d358f9f6269f5d9237813d0b825c7d70a143"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-#{arch}-#{version}.tar.gz"


### PR DESCRIPTION
This fixes an issue caused by Homebrew/brew@0b3d758. This is why the `Homebrew Bump` workflow has been failing for a while now.

Checks that were done locally:
- `brew style --fix`: Validated syntax and Homebrew file compliance.
- `brew livecheck`: Checked that it could retrieve latest updates.
- `brew fetch`: Validated that downloading and evaluating architectures doesn't crash on Linux platforms.