### PR TITLE
Fix antigravity asar json header

### DIFF
--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -47,13 +47,15 @@ cask "antigravity-linux" do
     if File.exist?(asar_path)
       File.open(asar_path, "rb") do |asar|
         asar.seek(8)
-        header_size = asar.read(4).unpack1("V") - 4
+        padded_size = asar.read(4).unpack1("V") - 4
+        asar.seek(12)
+        true_size = asar.read(4).unpack1("V")
         asar.seek(16)
-        header = JSON.parse(asar.read(header_size))
+        header = JSON.parse(asar.read(true_size))
         icon_entry = header.dig("files", "icon.png")
 
         if icon_entry
-          asar.seek(16 + header_size + icon_entry["offset"].to_i)
+          asar.seek(16 + padded_size + icon_entry["offset"].to_i)
           File.binwrite("#{staged_path}/antigravity.png", asar.read(icon_entry["size"]))
         end
       end

--- a/Casks/bazzite-wallpapers.rb
+++ b/Casks/bazzite-wallpapers.rb
@@ -2,7 +2,8 @@ cask "bazzite-wallpapers" do
   version "2025-12-14"
   sha256 "21bfa43889d68e4fcbe67b17a2626d5f752138bf751dd67f0c90f4bf820f1374"
 
-  url "https://github.com/ublue-os/artwork/releases/download/bazzite-v#{version}/bazzite-wallpapers.tar.zstd"
+  url "https://github.com/ublue-os/artwork/releases/download/bazzite-v#{version}/bazzite-wallpapers.tar.zstd",
+      verified: "github.com/ublue-os/artwork/"
   name "bazzite-wallpapers"
   desc "Wallpapers for Bazzite"
   homepage "https://bazzite.gg/"

--- a/Casks/vscodium-linux.rb
+++ b/Casks/vscodium-linux.rb
@@ -8,7 +8,8 @@ cask "vscodium-linux" do
          arm64_linux:  "73d87d46d4dc208fe12c0497dc607aab0a6e2bf332f54a0b6826a3a1aa32bc34",
          x86_64_linux: "adf3548df055d18e476cdee887488ba7486b879ad99a31a546c6b5c5ff296c24"
 
-  url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-#{arch}-#{version}.tar.gz"
+  url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-#{arch}-#{version}.tar.gz",
+      verified: "github.com/VSCodium/vscodium/"
   name "VSCodium"
   desc "Open-source code editor"
   homepage "https://vscodium.com/"


### PR DESCRIPTION
Google added padding to the JSON header in the Asar file, which broke the cask.

Since Asar has the true size and the padded size of the JSON header, let's just use that to make sure if it changes later, it will still work.

Tested locally by replacing the currently broken `antigravity-local.rb` file with this one and made sure Homebrew now installs the cask correctly.