### PR TITLE
fix: build litellm with -O0 to fix aws-lc-sys jitterentropy

### DIFF
--- a/Casks/zed-linux.rb
+++ b/Casks/zed-linux.rb
@@ -1,0 +1,45 @@
+cask "zed-linux" do
+  version "1.14.2"
+  sha256 "6c476103b49a87dc62c46b8cc4dca84c0458ed53537de664ebdbc99b47daee2d"
+
+  url "https://github.com/zed-industries/zed/releases/download/v#{version}/zed-linux-x86_64.tar.gz"
+  name "Zed"
+  desc "High-performance, multiplayer code editor"
+  homepage "https://zed.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "zed.app/bin/zed"
+
+  preflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.mkdir_p "#{xdg_data}/applications"
+    FileUtils.mkdir_p "#{xdg_data}/icons"
+  end
+
+  postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    desktop_content = File.read("#{staged_path}/zed.app/share/applications/dev.zed.Zed.desktop")
+    desktop_content.gsub!(/^TryExec=.*/, "TryExec=#{HOMEBREW_PREFIX}/bin/zed")
+    desktop_content.gsub!(/^Exec=zed/, "Exec=#{HOMEBREW_PREFIX}/bin/zed")
+    desktop_content.gsub!(/^Icon=.*/, "Icon=zed")
+    File.write("#{xdg_data}/applications/dev.zed.Zed.desktop", desktop_content)
+    FileUtils.cp("#{staged_path}/zed.app/share/icons/hicolor/512x512/apps/zed.png",
+                 "#{xdg_data}/icons/zed.png")
+  end
+
+  uninstall_postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.rm("#{xdg_data}/applications/dev.zed.Zed.desktop")
+    FileUtils.rm("#{xdg_data}/icons/zed.png")
+  end
+
+  zap trash: [
+    "#{ENV.fetch("XDG_CACHE_HOME", "#{Dir.home}/.cache")}/zed",
+    "#{ENV.fetch("XDG_CONFIG_HOME", "#{Dir.home}/.config")}/zed",
+    "#{ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")}/zed",
+  ]
+end

--- a/Formula/linux-mcp-server.rb
+++ b/Formula/linux-mcp-server.rb
@@ -545,11 +545,12 @@ class LinuxMcpServer < Formula
 
     venv = virtualenv_create(libexec, "python3.12")
 
-    # Install hf-xet separately: aws-lc-sys's jitterentropy requires -O0 but
-    # Homebrew sets -Os globally which overrides CMake's per-target flags
+    # Install hf-xet and litellm separately: their aws-lc-sys builds require -O0
+    # (jitterentropy) but Homebrew sets -Os globally which overrides CMake's per-target flags
     ENV.O0 { venv.pip_install resource("hf-xet") }
+    ENV.O0 { venv.pip_install resource("litellm") }
 
-    venv.pip_install resources.reject { |r| r.name == "hf-xet" }
+    venv.pip_install resources.reject { |r| %w[hf-xet litellm].include?(r.name) }
     venv.pip_install_and_link buildpath
 
     # Install the goose configuration setup script

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ brew install --cask antigravity-ide-linux
 brew install --cask antigravity-cli-linux
 brew install --cask asusctl-linux
 brew install --cask rog-control-center-linux
+brew install --cask zed-linux
 
 brew install --cask bluefin-wallpapers
 brew install --cask bluefin-wallpapers-extra
@@ -57,6 +58,7 @@ brew install --cask framework-wallpapers
 - VSCodium - Open-source build of VS Code
 - Framework System Tool - Hardware management for Framework laptops
 - rog control center - GUI frontend for asusctl (for Asus ROG etc laptops)
+- Zed - High-performance, multiplayer code editor
 
 ### Wallpapers
 


### PR DESCRIPTION
## Problem

The bottle build for linux-mcp-server 1.5.0 fails on both runners ([run 31077989151](https://github.com/ublue-os/homebrew-tap/actions/runs/31077989151)):

```
jitterentropy-base.c:47:3: error: #error "The CPU Jitter random number generator must not be compiled with optimizations. ... Use the compiler switch -O0"
```

litellm 1.95.0 now ships a Rust bridge (litellm-rust) that builds aws-lc-sys 0.43.0, whose jitterentropy target hard-errors unless compiled with -O0. Homebrew sets -Os globally, which overrides CMake's per-target flags.

## Fix

Install litellm separately with ENV.O0, the same workaround already used for hf-xet (which has the identical issue).

Verified locally: brew install --build-bottle succeeds and brew bottle produces a valid 1.5.0 bottle.

## After merge

The bottle-linux-mcp-server.yml workflow will rebuild the 1.5.0 bottles, create the linux-mcp-server-1.5.0 release, and update the formula bottle block automatically.