### PR TITLE
fix(goose-linux): update StartupWMClass to lowercase

### DIFF
--- a/Casks/goose-linux.rb
+++ b/Casks/goose-linux.rb
@@ -50,7 +50,7 @@ cask "goose-linux" do
       Type=Application
       Categories=Development;
       MimeType=x-scheme-handler/goose;
-      StartupWMClass=Goose
+      StartupWMClass=goose
     EOS
   end
 


### PR DESCRIPTION
StartupWMClass is case sensitive, set lowercase to match exposed WMClass.