### PR TITLE
[WIP] Add T3 Code Linux cask

### DIFF
--- a/Casks/t3-code-linux.rb
+++ b/Casks/t3-code-linux.rb
@@ -1,0 +1,38 @@
+cask "t3-code-linux" do
+  version "0.0.33"
+  sha256 "415c8648f43c3d22d572f27f2c50fdc8c310ea7fcde9537b903e1e2f1c8775a1"
+
+  url "https://github.com/pingdotgg/t3code/releases/download/v#{version}/T3-Code-#{version}-x86_64.AppImage"
+  name "T3 Code"
+  desc "Desktop control surface for local coding agents"
+  homepage "https://github.com/pingdotgg/t3code"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on formula: "squashfs"
+
+  binary "squashfs-root/AppRun", target: "t3code"
+  artifact "squashfs-root/usr/share/icons/hicolor/512x512/apps/t3code.png",
+           target: "#{Dir.home}/.local/share/icons/t3code.png"
+  artifact "squashfs-root/t3code.desktop",
+           target: "#{Dir.home}/.local/share/applications/t3code.desktop"
+
+  preflight do
+    appimage_path = "#{staged_path}/T3-Code-#{version}-x86_64.AppImage"
+    system "chmod", "+x", appimage_path
+    system appimage_path, "--appimage-extract", chdir: staged_path
+    FileUtils.rm appimage_path
+
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons"
+
+    desktop_path = "#{staged_path}/squashfs-root/t3code.desktop"
+    desktop_content = File.read(desktop_path)
+    # AppRun adds --no-sandbox itself when unprivileged user namespaces are unavailable.
+    desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/t3code %U")
+    File.write(desktop_path, desktop_content)
+  end
+end

--- a/Casks/t3-code-linux.rb
+++ b/Casks/t3-code-linux.rb
@@ -1,6 +1,6 @@
 cask "t3-code-linux" do
-  version "0.0.33"
-  sha256 "415c8648f43c3d22d572f27f2c50fdc8c310ea7fcde9537b903e1e2f1c8775a1"
+  version "0.0.34"
+  sha256 "6077e207cc1e7e65858f73313534abe1da357227f40225854e1abac34dedba04"
 
   url "https://github.com/pingdotgg/t3code/releases/download/v#{version}/T3-Code-#{version}-x86_64.AppImage"
   name "T3 Code"
@@ -14,7 +14,7 @@ cask "t3-code-linux" do
 
   depends_on formula: "squashfs"
 
-  binary "squashfs-root/AppRun", target: "t3code"
+  binary "t3code.wrapper.sh", target: "t3code"
   artifact "squashfs-root/usr/share/icons/hicolor/512x512/apps/t3code.png",
            target: "#{Dir.home}/.local/share/icons/t3code.png"
   artifact "squashfs-root/t3code.desktop",
@@ -25,6 +25,13 @@ cask "t3-code-linux" do
     system "chmod", "+x", appimage_path
     system appimage_path, "--appimage-extract", chdir: staged_path
     FileUtils.rm appimage_path
+
+    File.write("#{staged_path}/t3code.wrapper.sh", <<~EOS)
+      #!/bin/sh
+      export T3CODE_DISABLE_AUTO_UPDATE=1
+      exec "#{staged_path}/squashfs-root/AppRun" "$@"
+    EOS
+    FileUtils.chmod 0755, "#{staged_path}/t3code.wrapper.sh"
 
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
     FileUtils.mkdir_p "#{Dir.home}/.local/share/icons"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ brew install --cask antigravity-ide-linux
 brew install --cask antigravity-cli-linux
 brew install --cask asusctl-linux
 brew install --cask rog-control-center-linux
+brew install --cask t3-code-linux
 brew install --cask zed-linux
 
 brew install --cask bluefin-wallpapers
@@ -58,6 +59,7 @@ brew install --cask framework-wallpapers
 - VSCodium - Open-source build of VS Code
 - Framework System Tool - Hardware management for Framework laptops
 - rog control center - GUI frontend for asusctl (for Asus ROG etc laptops)
+- T3 Code - Desktop control surface for local coding agents
 - Zed - High-performance, multiplayer code editor
 
 ### Wallpapers


### PR DESCRIPTION
# Add T3 Code Linux cask

## Summary

- add an x86_64 Linux cask for the latest stable T3 Code release
- extract the upstream AppImage during installation so T3 Code works on systems where user-level AppImage FUSE mounts are unavailable
- install a `t3code` launcher, desktop entry, and application icon
- disable T3 Code's AppImage self-updater so Homebrew remains responsible for upgrades
- rewrite the desktop launcher to use Homebrew's managed binary and avoid the bundled unconditional `--no-sandbox` flag
- document the new cask in the tap README

The extraction approach follows the existing `lm-studio-linux` cask and T3 Code's upstream-maintained AUR package:

- https://github.com/ublue-os/homebrew-tap/blob/main/Casks/lm-studio-linux.rb
- https://github.com/pingdotgg/t3code/blob/main/packaging/aur/t3code-bin/PKGBUILD

## Sandbox behavior

The AppImage's bundled desktop entry currently uses:

```text
Exec=AppRun --no-sandbox %U
```

This cask rewrites it to the Homebrew-managed launcher without the unconditional flag:

```text
Exec=<Homebrew prefix>/bin/t3code %U
```

This is intentional, but worth discussion:

- The bundled `AppRun` already probes `unshare -Ur true` and adds `--no-sandbox` itself when unprivileged user namespaces are unavailable.
- Testing in a Dakota/Bluefin GNOME OS VM confirmed the intended conditional path. `unshare -Ur true` succeeded, and the global `--no-sandbox` flag was absent from all eight observed T3 Code process command lines. A sandboxed Chromium child ran in separate user and PID namespaces, reported nested `NSpid` values, and had `NoNewPrivs: 1` and `Seccomp: 2`.
- The extracted `chrome-sandbox` is user-owned and mode `0755`; a user-owned Homebrew cask cannot safely reproduce T3 Code's AUR package behavior of installing it root-owned with mode `4755`.
- Keeping upstream's unconditional `--no-sandbox` may maximize compatibility on unusual hosts, but disables Electron's Chromium sandbox even where the safer user-namespace path works.

The current draft prefers the conditional behavior already implemented by `AppRun`. If the tap's compatibility policy is to preserve the upstream desktop flag verbatim, the replacement can instead retain `--no-sandbox`.

## Update behavior

The launcher exports T3 Code's supported `T3CODE_DISABLE_AUTO_UPDATE=1` setting. The Linux self-updater downloads another AppImage, which would bypass Homebrew's version and checksum management and may not be executable on the systems this cask is intended to support. Updates should instead be applied with:

```text
brew upgrade --cask t3-code-linux
```

## Testing

- `brew style Casks/t3-code-linux.rb`
- Homebrew Ruby syntax and DSL loading
- verified the `v0.0.34` AppImage SHA-256 before extraction
- verified one-time AppImage extraction produces the declared `AppRun`, desktop, and icon artifacts
- installed cask version `0.0.33` in a Dakota/Bluefin GNOME OS VM using a disposable local tap; Homebrew 5.0.16 rejects direct filesystem cask installation
- launched T3 Code from the installed desktop entry and verified the normal project-selection GUI renders
- performed three consecutive full process-tree terminations and launches from the installed desktop entry; all three clean starts reached the normal GUI without manual recovery
- verified `unshare -Ur true` succeeds
- inspected all eight observed T3 Code processes and confirmed the global `--no-sandbox` flag is absent
- confirmed a sandboxed Chromium child uses separate user and PID namespaces, nested `NSpid` values, `NoNewPrivs: 1`, and `Seccomp: 2`
- on the first launch, the UI reported a `fetch-session-state` HTTP 500. The working workaround was the built-in **Reload App** action; both embedded endpoints returned HTTP 200. Three subsequent full quit and desktop-entry launch cycles succeeded directly (3/3). The symptom is consistent with [pingdotgg/t3code#3513](https://github.com/pingdotgg/t3code/issues/3513), but this small sample does not prove the cask path played no role. This should remain disclosed and receive additional testing even if ultimately confirmed as an upstream application bug.

## Notes

- T3 Code currently publishes the Linux AppImage for x86_64 only.
- `livecheck` follows the latest non-prerelease GitHub release.
- GUI evidence currently covers `0.0.33`; the `0.0.34` version bump and explicit updater opt-out still need the planned clean VM retest before the PR is marked ready.
- Upstream guidance on update ownership and AppImage sandbox policy has been requested in [pingdotgg/t3code#8288](https://github.com/pingdotgg/t3code/discussions/8288).
