### PR TITLE
lm-studio-linux: fix AppImage paths for 0.4.23

### DIFF
--- a/Casks/lm-studio-linux.rb
+++ b/Casks/lm-studio-linux.rb
@@ -21,9 +21,9 @@ cask "lm-studio-linux" do
   depends_on formula: "squashfs"
 
   binary "squashfs-root/AppRun", target: "lm-studio"
-  artifact "squashfs-root/usr/share/icons/hicolor/0x0/apps/lm-studio.png",
+  artifact "squashfs-root/usr/share/icons/hicolor/512x512/apps/lm-studio.png",
            target: "#{Dir.home}/.local/share/icons/lm-studio.png"
-  artifact "squashfs-root/lm-studio.desktop",
+  artifact "squashfs-root/ai.elementlabs.lmstudio.desktop",
            target: "#{Dir.home}/.local/share/applications/lm-studio.desktop"
 
   preflight do
@@ -38,9 +38,9 @@ cask "lm-studio-linux" do
     FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
     FileUtils.mkdir_p "#{Dir.home}/.local/share/icons"
 
-    desktop_content = File.read("#{staged_path}/squashfs-root/lm-studio.desktop")
+    desktop_content = File.read("#{staged_path}/squashfs-root/ai.elementlabs.lmstudio.desktop")
     desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/lm-studio")
-    File.write("#{staged_path}/squashfs-root/lm-studio.desktop", desktop_content)
+    File.write("#{staged_path}/squashfs-root/ai.elementlabs.lmstudio.desktop", desktop_content)
   end
 
   zap trash: "~/.config/LMStudio"


### PR DESCRIPTION
LM Studio 0.4.23 renamed the bundled desktop file to ai.elementlabs.lmstudio.desktop and removed the hicolor/0x0 symlink icon directory (icons now live under real size directories). The cask still referenced the old paths, so install failed during preflight with:

  No such file or directory @ rb_sysopen -
  .../Caskroom/lm-studio-linux/0.4.23-1/squashfs-root/lm-studio.desktop

Point the icon artifact at hicolor/512x512/apps/lm-studio.png and use the renamed desktop file for the artifact and preflight patch.