### PR TITLE
fix: restore tap CI on current Homebrew

### DIFF
--- a/Casks/1password-cli-linux.rb
+++ b/Casks/1password-cli-linux.rb
@@ -25,29 +25,18 @@ cask "1password-cli-linux" do
   binary "op"
   generate_completions_from_executable "op", "completion"
 
-  postflight do
-    # For the 1Password desktop app integration to trust the CLI, the op
-    # binary must be owned by root:onepassword-cli with the setgid bit set.
-    # The deb/rpm packages set this up in their post-install scripts; since
-    # this cask installs from the zip, it has to do the same. Running this
-    # in postflight also re-applies the permissions on every upgrade.
+  postflight_steps do
+    # Desktop integration requires root:onepassword-cli ownership and setgid.
     # https://developer.1password.com/docs/cli/app-integration/
-    system <<~EOS
-      #!/bin/bash
-      if [ ! "$(getent group onepassword-cli)" ]; then
-        echo "Creating group 'onepassword-cli' for the 1Password desktop app integration, you may be prompted for your password."
-        sudo groupadd onepassword-cli
-      fi
-    EOS
-    set_ownership("#{staged_path}/op", user: "root", group: "onepassword-cli")
-    # can't use set_permissions here because we no longer own the file and brew tries to run chmod without sudo
-    system "sudo", "chmod", "2755", "#{File.expand_path(staged_path)}/op"
+    run "/bin/sh", args: ["-eu", "-c", "getent group onepassword-cli >/dev/null || groupadd onepassword-cli"],
+                   sudo: true
+    set_ownership "op", user: "root", group: "onepassword-cli", recursive: false
+    run "/bin/chmod", args: ["2755", "{{staged_path}}/op"], sudo: true
   end
 
-  uninstall_preflight do
-    # re-take ownership of the binary so brew can remove it without sudo
-    system "sudo", "chown", "#{ENV.fetch("USER", nil)}:#{ENV.fetch("USER", nil)}",
-           "#{File.expand_path(staged_path)}/op"
+  uninstall_preflight_steps do
+    # Return ownership to the installing user before Homebrew removes the binary.
+    run "/bin/chown", args: ["{{user}}:", "{{staged_path}}/op"], sudo: true
   end
 
   zap trash: "~/.config/op"

--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -1,5 +1,10 @@
 cask "1password-gui-linux" do
   arch arm: "aarch64", intel: "x86_64"
+  arch_suffix =
+    case arch
+    when "aarch64" then "arm64"
+    when "x86_64" then "x64"
+    end
   os linux: "linux"
 
   version "8.12.34"
@@ -7,12 +12,6 @@ cask "1password-gui-linux" do
          intel:        "297784aa66770b645607a7f04c9ba2c4aebed4f46d21202487f521ba572b7b13",
          arm64_linux:  "ea5102363d6cf3442b96a7abd6743da8c1d261f56a628e1a3c183d84fa65fdcb",
          x86_64_linux: "297784aa66770b645607a7f04c9ba2c4aebed4f46d21202487f521ba572b7b13"
-
-  arch_suffix =
-    case arch
-    when "aarch64" then "arm64"
-    when "x86_64" then "x64"
-    end
 
   url "https://downloads.1password.com/linux/tar/stable/#{arch}/1password-#{version}.#{arch_suffix}.tar.gz"
   name "1Password"
@@ -27,239 +26,149 @@ cask "1password-gui-linux" do
     end
   end
 
-  binary "1password-#{version}.#{arch_suffix}/1password", target: "1password"
-  binary "1password-#{version}.#{arch_suffix}/op-ssh-sign", target: "op-ssh-sign"
-  binary "1password-#{version}.#{arch_suffix}/1Password-BrowserSupport", target: "1Password-BrowserSupport"
-  binary "1password-#{version}.#{arch_suffix}/1Password-Crash-Handler", target: "1Password-Crash-Handler"
-  binary "1password-#{version}.#{arch_suffix}/1Password-LastPass-Exporter", target: "1Password-LastPass-Exporter"
-  artifact "1password-#{version}.#{arch_suffix}/resources/1password.desktop",
+  depends_on formula: "jq"
+
+  binary "1password/1password", target: "1password"
+  binary "1password/op-ssh-sign", target: "op-ssh-sign"
+  binary "1password/1Password-BrowserSupport", target: "1Password-BrowserSupport"
+  binary "1password/1Password-Crash-Handler", target: "1Password-Crash-Handler"
+  binary "1password/1Password-LastPass-Exporter", target: "1Password-LastPass-Exporter"
+  artifact "1password/resources/1password.desktop",
            target: "#{Dir.home}/.local/share/applications/1password.desktop"
-  artifact "1password-#{version}.#{arch_suffix}/resources/icons/hicolor/256x256/apps/1password.png",
+  artifact "1password/resources/icons/hicolor/256x256/apps/1password.png",
            target: "#{Dir.home}/.local/share/icons/1password.png"
-  artifact "1password-#{version}.#{arch_suffix}/com.1password.1Password.policy.tpl",
+  artifact "1password/com.1password.1Password.policy.tpl",
            target: "#{HOMEBREW_PREFIX}/etc/polkit-1/actions/com.1password.1Password.policy"
-  artifact "1password-#{version}.#{arch_suffix}/resources/custom_allowed_browsers",
+  artifact "1password/resources/custom_allowed_browsers",
            target: "#{HOMEBREW_PREFIX}/etc/1password/custom_allowed_browsers"
 
-  preflight do
-    desktop_file = "#{staged_path}/1password-#{version}.#{arch_suffix}/resources/1password.desktop"
-    text = File.read(desktop_file)
-    new_contents = text.gsub("Exec=/opt/1Password/1password", "Exec=#{HOMEBREW_PREFIX}/bin/1password")
-    File.write(desktop_file, new_contents)
-
-    # set up flatpak browser support
-    browser_config = "#{staged_path}/1password-#{version}.#{arch_suffix}/resources/custom_allowed_browsers"
-    File.open(browser_config, "a") do |f|
-      f.write "\nflatpak-session-helper"
-    end
+  preflight_steps do
+    move "1password-*", "1password", source_glob: true
+    symlink ".", ".user-home", source_base: :home, overwrite: true
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons", base: :home
+    inreplace "1password/resources/1password.desktop", "Exec=/opt/1Password/1password",
+              "Exec={{HOMEBREW_PREFIX}}/bin/1password"
+    run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
+      printf '\nflatpak-session-helper\n' >> 1password/resources/custom_allowed_browsers
+      owners=$(awk -F: '$3 >= 1000 && $3 <= 9999 && $1 != "nobody" && count++ < 10 {printf "unix-user:%s ", $1}' /etc/passwd)
+      sed "s/\${POLICY_OWNERS}/$owners/g" 1password/com.1password.1Password.policy.tpl > 1password/com.1password.1Password.policy
+    SH
   end
 
-  postflight do
-    system "echo", "Installing polkit policy file to /etc/polkit-1/actions/, you may be prompted for your password."
-    if !File.exist?("/etc/polkit-1/actions/com.1password.1Password.policy") ||
-       !FileUtils.identical?("#{staged_path}/1password-#{version}.#{arch_suffix}/com.1password.1Password.policy.tpl",
-                             "/etc/polkit-1/actions/com.1password.1Password.policy")
-
-      # Get users from /etc/passwd and output first 10 human users (1000 >= UID <= 9999) to the policy file
-      # format: `unix-user:username` space separated
-      # This is used to allow these users to unlock 1Password via polkit.
-      human_users = `awk -F: '$3 >= 1000 && $3 <= 9999 && $1 != "nobody" { print $1 }' /etc/passwd`
-                    .split("\n").first(10)
-      policy_owners = human_users.map { |user| "unix-user:#{user}" }.join(" ")
-      policy_file = File.read("#{staged_path}/1password-#{version}.#{arch_suffix}/com.1password.1Password.policy.tpl")
-      replaced_contents = policy_file.gsub("${POLICY_OWNERS}", policy_owners)
-      File.write("#{staged_path}/1password-#{version}.#{arch_suffix}/com.1password.1Password.policy", replaced_contents)
-      system "sudo", "install", "-Dm0644",
-             "#{staged_path}/1password-#{version}.#{arch_suffix}/com.1password.1Password.policy",
-             "/etc/polkit-1/actions/com.1password.1Password.policy"
-      puts "Installed /etc/polkit-1/actions/com.1password.1Password.policy"
-    else
-      puts "Skipping installation of /etc/polkit-1/actions/com.1password.1Password.policy,
-      as it already exists and is the same as the version to be installed."
-    end
-
-    if !File.exist?("/etc/1password/custom_allowed_browsers") ||
-       File.readlines("/etc/1password/custom_allowed_browsers").grep(/^flatpak-session-helper/).none?
-      if File.exist?("/etc/1password/custom_allowed_browsers")
-        # append the flatpak-session-helper to the existing custom_allowed_browsers file
-        File.open("/etc/1password/custom_allowed_browsers", "a") do |f|
-          f.write "\nflatpak-session-helper"
-        end
-        puts "Added flatpak-session-helper to /etc/1password/custom_allowed_browsers"
-      else
-        puts "Installing custom allowed browsers file to /etc/1password/, you may be prompted for your password."
-        system "sudo", "install", "-Dm0644",
-               "#{staged_path}/1password-#{version}.#{arch_suffix}/resources/custom_allowed_browsers",
-               "/etc/1password/custom_allowed_browsers"
-      end
-    else
-      puts "Skipping installation of /etc/1password/custom_allowed_browsers " \
-           "as it already exists and contains flatpak-session-helper"
-    end
-
-    File.write("#{staged_path}/zpass.sh", <<~EOS)
-      #!/bin/bash
-      zenity --password --title="Homebrew Sudo Password Prompt"
-    EOS
-    set_permissions("#{staged_path}/zpass.sh", "755")
-
-    # 1Password browser support binary needs to be owned by group onepassword and
-    # have the GID bit set in order to function
-    system <<~EOS
-      #!/bin/bash
-      if [ ! "$(getent group onepassword)" ]; then
-        echo "Creating group 'onepassword' for 1Password browser support, you may be prompted for your password."
-        sudo groupadd onepassword
-      fi
-    EOS
-    set_ownership("#{staged_path}/1password-#{version}.#{arch_suffix}/1Password-BrowserSupport", user: "root", group: "onepassword")
-    # can't use set_permissions here because we no longer own the file and brew tries to run chmod without sudo
-    system "sudo", "chmod", "2755", "#{File.expand_path(staged_path)}/1password-#{version}.#{arch_suffix}/1Password-BrowserSupport"
-
-    # the 1Password binary also needs to be owned by root so it can be executed by
-    # browser support which runs with elevated permissions
-    set_ownership("#{staged_path}/1password-#{version}.#{arch_suffix}/1password", user: "root", group: "root")
-
-    # chrome-sandbox requires the setuid bit to be specifically set.
-    # See https://github.com/electron/electron/issues/17972
-    set_ownership("#{staged_path}/1password-#{version}.#{arch_suffix}/chrome-sandbox", user: "root", group: "root")
-    system "sudo", "chmod", "4755", "#{File.expand_path(staged_path)}/1password-#{version}.#{arch_suffix}/chrome-sandbox"
-
-    File.open("#{staged_path}/1PasswordWrapper.sh", "w", 0755) do |f|
-      f.write <<~EOS
-        #!/bin/bash
-        if [ "${container-}" = flatpak ]; then
-          flatpak-spawn --host "#{File.expand_path(HOMEBREW_PREFIX)}/bin/1Password-BrowserSupport" "$@"
-        else
-          exec "#{File.expand_path(HOMEBREW_PREFIX)}/bin/1Password-BrowserSupport" "$@"
+  postflight_steps do
+    # System policy and browser allowlist require privilege; user browser files do not.
+    run "/bin/sh", args: ["-eu", "-c", <<~'SH', "--", "{{staged_path}}/1password"], sudo: true
+      install -Dm0644 "$1/com.1password.1Password.policy" /etc/polkit-1/actions/com.1password.1Password.policy
+      if [ -f /etc/1password/custom_allowed_browsers ]; then
+        if ! grep -q '^flatpak-session-helper' /etc/1password/custom_allowed_browsers; then
+          printf '\nflatpak-session-helper\n' >> /etc/1password/custom_allowed_browsers
         fi
-      EOS
-    end
-
-    # this list of supported native messaging hosts paths was retrieved by examining the 1Password log file at
-    #  #{Dir.home}/.config/1Password/logs/1Password_rCURRENT.log
-    native_messaging_hosts_paths = ["#{Dir.home}/.mozilla/native-messaging-hosts",
-                                    "#{Dir.home}/.config/google-chrome/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/google-chrome-beta/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/google-chrome-unstable/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/chromium/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/microsoft-edge-dev/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/vivaldi/NativeMessagingHosts",
-                                    "#{Dir.home}/.config/vivaldi-snapshot/NativeMessagingHosts"]
-
-    native_messaging_hosts_paths.each do |nmh_path|
-      script_path = "#{File.expand_path(nmh_path)}/1PasswordWrapper.sh"
-      # copy wrapper script to each browser support folder so the flatpak filesystem restrictions
-      # won't prevent the browser from launching it
-      system "cp", "-f", "#{staged_path}/1PasswordWrapper.sh", script_path.to_s
-
-      manifest_content=<<~EOS
-        {
-          "name": "com.1password.1password",
-          "description": "1Password BrowserSupport",
-          "path": "#{script_path}",
-          "type": "stdio",
-          "allowed_origins": [
-            "chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo/",
-            "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl/",
-            "chrome-extension://gejiddohjgogedgjnonbofjigllpkmbf/",
-            "chrome-extension://khgocmkkpikpnmmkgmdnfckapcdkgfaf/",
-            "chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/",
-            "chrome-extension://dppgmdbiimibapkepcbdbmkaabgiofem/"
-          ]
-        }
-      EOS
-
-      # Firefox is the only supported browser which has a different manifest
-      manifest_content_firefox=<<~EOS
-        {
-            "name": "com.1password.1password",
-            "description": "1Password BrowserSupport",
-            "path": "#{script_path}",
-            "type": "stdio",
-            "allowed_extensions": [
-              "{0a75d802-9aed-41e7-8daa-24c067386e82}",
-              "{25fc87fa-4d31-4fee-b5c1-c32a7844c063}",
-              "{d634138d-c276-4fc8-924b-40a0ea21d284}"
-            ]
-        }
-      EOS
-
-      manifest_path = "#{nmh_path}/com.1password.1password.json"
-      if File.exist?(manifest_path)
-        manifest = JSON.parse(File.read(manifest_path))
-        if manifest["path"] == script_path
-          puts "Found native messaging host manifest in #{manifest_path} " \
-               "which already has flatpak browser support, skipping update."
-        else
-          puts "Updating native messaging host manifest in #{manifest_path} " \
-               "to support flatpak browsers you may be prompted for your password."
-          manifest["path"] = script_path
-          system "echo '#{JSON.pretty_generate(manifest)}' | sudo tee #{manifest_path} >/dev/null"
-        end
       else
-        puts "Installing native messaging host manifest with flatpak browser support to #{nmh_path}, " \
-             "you may be prompted for your password."
-        system "sudo", "touch", manifest_path.to_s
-        system "echo '#{nmh_path.include?("mozilla")? manifest_content_firefox : manifest_content}' " \
-               "| sudo tee #{manifest_path} >/dev/null"
-      end
-      # set NMH manifests to read-only or else 1Password will overwrite them on launch
-      system "sudo", "chown", "#{ENV.fetch("USER", nil)}:#{ENV.fetch("USER", nil)}", manifest_path.to_s
-      system "sudo", "chmod", "444", manifest_path.to_s
-    end
-
-    File.write("#{staged_path}/1password-uninstall.sh", <<~EOS)
-      #!/bin/bash
-      set -e
-
-      SUDO_ASKPASS=#{staged_path}/zpass.sh
-      echo "Uninstalling polkit policy file from /etc/polkit-1/actions/com.1password.1Password.policy"
-      if [ -f /etc/polkit-1/actions/com.1password.1Password.policy ]; then
-        sudo rm -f /etc/polkit-1/actions/com.1password.1Password.policy
-        echo "Removed /etc/polkit-1/actions/com.1password.1Password.policy"
-      else
-        echo "/etc/polkit-1/actions/com.1password.1Password.policy does not exist, skipping."
+        install -Dm0644 "$1/resources/custom_allowed_browsers" /etc/1password/custom_allowed_browsers
       fi
+      getent group onepassword >/dev/null || groupadd onepassword
+    SH
+    set_ownership "1password/1Password-BrowserSupport", user: "root", group: "onepassword", recursive: false
+    run "/bin/chmod", args: ["2755", "{{staged_path}}/1password/1Password-BrowserSupport"], sudo: true
+    set_ownership ["1password/1password", "1password/chrome-sandbox"], user: "root", group: "root", recursive: false
+    run "/bin/chmod", args: ["4755", "{{staged_path}}/1password/chrome-sandbox"], sudo: true
 
-      # re-take ownership of the directory and binaries so we can remove them
-      sudo chown "$(whoami)":"$(whoami)" \
-       "#{staged_path}/1password-#{version}.#{arch_suffix}" \
-       "#{staged_path}/1password-#{version}.#{arch_suffix}/1password" \
-       "#{staged_path}/1password-#{version}.#{arch_suffix}/1Password-BrowserSupport" \
-       "#{staged_path}/1password-#{version}.#{arch_suffix}/chrome-sandbox"
-
-      native_messaging_hosts_paths=(
-        "$HOME/.mozilla/native-messaging-hosts"
-        "$HOME/.config/google-chrome/NativeMessagingHosts"
-        "$HOME/.config/google-chrome-beta/NativeMessagingHosts"
-        "$HOME/.config/google-chrome-unstable/NativeMessagingHosts"
-        "$HOME/.config/chromium/NativeMessagingHosts"
-        "$HOME/.config/microsoft-edge-dev/NativeMessagingHosts"
-        "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
-        "$HOME/.config/vivaldi/NativeMessagingHosts"
-        "$HOME/.config/vivaldi-snapshot/NativeMessagingHosts"
-      )
-      #set NMH manifests back to read-write so 1Password can clean them up on uninstall
-      for nmh_path in "${native_messaging_hosts_paths[@]}"; do
-        manifest_file="$nmh_path/com.1password.1password.json"
-        if [ -f "$manifest_file" ]; then
-          echo "allowing write access to $manifest_file for 1Password uninstallation"
-          sudo chmod 644 "$manifest_file"
-        fi
-        echo "removing wrapper script from $nmh_path/1PasswordWrapper.sh"
-        sudo rm -f "$nmh_path/1PasswordWrapper.sh"
-      done
-    EOS
-    set_permissions("#{staged_path}/1password-uninstall.sh", "740")
-
-    # set the folder to be owned by root so browser support has access
-    system "sudo", "chown", "root:root", "#{staged_path}/1password-#{version}.#{arch_suffix}"
+    write_file "1PasswordWrapper.sh", <<~SH
+      #!/bin/bash
+      if [ "${container-}" = flatpak ]; then
+        exec flatpak-spawn --host "{{HOMEBREW_PREFIX}}/bin/1Password-BrowserSupport" "$@"
+      else
+        exec "{{HOMEBREW_PREFIX}}/bin/1Password-BrowserSupport" "$@"
+      fi
+    SH
+    set_permissions "1PasswordWrapper.sh", "755", recursive: false
+    write_file "native-messaging-chrome.json", <<~JSON
+      {
+        "name": "com.1password.1password",
+        "description": "1Password BrowserSupport",
+        "type": "stdio",
+        "allowed_origins": [
+          "chrome-extension://hjlinigoblmkhjejkmbegnoaljkphmgo/",
+          "chrome-extension://bkpbhnjcbehoklfkljkkbbmipaphipgl/",
+          "chrome-extension://gejiddohjgogedgjnonbofjigllpkmbf/",
+          "chrome-extension://khgocmkkpikpnmmkgmdnfckapcdkgfaf/",
+          "chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/",
+          "chrome-extension://dppgmdbiimibapkepcbdbmkaabgiofem/"
+        ]
+      }
+    JSON
+    write_file "native-messaging-firefox.json", <<~JSON
+      {
+        "name": "com.1password.1password",
+        "description": "1Password BrowserSupport",
+        "type": "stdio",
+        "allowed_extensions": [
+          "{0a75d802-9aed-41e7-8daa-24c067386e82}",
+          "{25fc87fa-4d31-4fee-b5c1-c32a7844c063}",
+          "{d634138d-c276-4fc8-924b-40a0ea21d284}"
+        ]
+      }
+    JSON
+    run "/bin/bash", chdir: "{{staged_path}}",
+                     env: { "BROWSER_HOME" => "{{staged_path}}/.user-home", "JQ" => "{{HOMEBREW_PREFIX}}/bin/jq" },
+                     writable_paths: [".mozilla/native-messaging-hosts", ".config/google-chrome/NativeMessagingHosts",
+                                      ".config/google-chrome-beta/NativeMessagingHosts",
+                                      ".config/google-chrome-unstable/NativeMessagingHosts",
+                                      ".config/chromium/NativeMessagingHosts",
+                                      ".config/microsoft-edge-dev/NativeMessagingHosts",
+                                      ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+                                      ".config/vivaldi/NativeMessagingHosts",
+                                      ".config/vivaldi-snapshot/NativeMessagingHosts"],
+                     writable_base: :home, args: ["-eu", "-c", <<~'SH']
+                       BROWSER_HOME=$(readlink "$BROWSER_HOME")
+                       for relative in .mozilla/native-messaging-hosts \
+                         .config/{google-chrome,google-chrome-beta,google-chrome-unstable,chromium,microsoft-edge-dev,BraveSoftware/Brave-Browser,vivaldi,vivaldi-snapshot}/NativeMessagingHosts; do
+                         directory="$BROWSER_HOME/$relative"
+                         mkdir -p "$directory"
+                         cp -f 1PasswordWrapper.sh "$directory/1PasswordWrapper.sh"
+                         chmod 755 "$directory/1PasswordWrapper.sh"
+                         manifest="$directory/com.1password.1password.json"
+                         source=native-messaging-chrome.json
+                         [[ "$relative" != .mozilla/* ]] || source=native-messaging-firefox.json
+                         [[ ! -f "$manifest" ]] || source="$manifest"
+                         temporary=$(mktemp "$directory/.1password-manifest.XXXXXX")
+                         trap 'rm -f "$temporary"' EXIT
+                         "$JQ" --arg path "$directory/1PasswordWrapper.sh" '.path = $path' "$source" > "$temporary"
+                         chmod 444 "$temporary"
+                         mv -f "$temporary" "$manifest"
+                       done
+                     SH
+    # BrowserSupport requires the payload directory itself to be root-owned too.
+    set_ownership "1password", user: "root", group: "root", recursive: false
   end
 
-  uninstall_preflight do
-    system "#{staged_path}/1password-uninstall.sh"
+  uninstall_preflight_steps do
+    symlink ".", ".user-home", source_base: :home, overwrite: true
+    remove "/etc/polkit-1/actions/com.1password.1Password.policy", sudo: true
+    run "/bin/chown", args: ["{{user}}:", "{{staged_path}}/1password", "{{staged_path}}/1password/1password",
+                             "{{staged_path}}/1password/1Password-BrowserSupport",
+                             "{{staged_path}}/1password/chrome-sandbox"],
+                      sudo: true
+    run "/bin/bash", env: { "BROWSER_HOME" => "{{staged_path}}/.user-home" },
+                     writable_paths: [".mozilla/native-messaging-hosts", ".config/google-chrome/NativeMessagingHosts",
+                                      ".config/google-chrome-beta/NativeMessagingHosts",
+                                      ".config/google-chrome-unstable/NativeMessagingHosts",
+                                      ".config/chromium/NativeMessagingHosts",
+                                      ".config/microsoft-edge-dev/NativeMessagingHosts",
+                                      ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+                                      ".config/vivaldi/NativeMessagingHosts",
+                                      ".config/vivaldi-snapshot/NativeMessagingHosts"],
+                     writable_base: :home, args: ["-eu", "-c", <<~'SH']
+                       BROWSER_HOME=$(readlink "$BROWSER_HOME")
+                       for relative in .mozilla/native-messaging-hosts \
+                         .config/{google-chrome,google-chrome-beta,google-chrome-unstable,chromium,microsoft-edge-dev,BraveSoftware/Brave-Browser,vivaldi,vivaldi-snapshot}/NativeMessagingHosts; do
+                         directory="$BROWSER_HOME/$relative"
+                         manifest="$directory/com.1password.1password.json"
+                         if [ -f "$manifest" ]; then chmod 644 "$manifest"; fi
+                         rm -f "$directory/1PasswordWrapper.sh"
+                       done
+                     SH
   end
 
   zap trash: [

--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -1,6 +1,5 @@
 cask "antigravity-linux" do
   arch arm: "arm", intel: "x64"
-  arch_dir = on_arch_conditional arm: "arm64", intel: "x64"
   os linux: "linux"
 
   version "2.12.2,6298742303883264"
@@ -25,7 +24,9 @@ cask "antigravity-linux" do
     end
   end
 
-  binary "#{staged_path}/Antigravity-#{arch_dir}/antigravity"
+  depends_on formula: "jq"
+
+  binary "Antigravity/antigravity"
   artifact "antigravity.desktop",
            target: "#{Dir.home}/.local/share/applications/antigravity.desktop"
   artifact "antigravity-url-handler.desktop",
@@ -33,42 +34,38 @@ cask "antigravity-linux" do
   artifact "antigravity.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
 
-  preflight do
-    app_root = "#{staged_path}/Antigravity-#{arch_dir}"
-    app_update_yml = "#{app_root}/resources/app-update.yml"
-    asar_path = "#{app_root}/resources/app.asar"
+  preflight_steps do
+    move "Antigravity-*", "Antigravity", source_glob: true
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
+    remove "Antigravity/resources/app-update.yml"
 
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
-
-    # Disable Electron auto-update checks; Homebrew manages this install.
-    FileUtils.rm app_update_yml
-
-    # Extract the app icon from the ASAR package without requiring external tools.
-    if File.exist?(asar_path)
-      File.open(asar_path, "rb") do |asar|
-        asar.seek(8)
-        padded_size = asar.read(4).unpack1("V") - 4
-        asar.seek(12)
-        true_size = asar.read(4).unpack1("V")
-        asar.seek(16)
-        header = JSON.parse(asar.read(true_size))
-        icon_entry = header.dig("files", "icon.png")
-
-        if icon_entry
-          asar.seek(16 + padded_size + icon_entry["offset"].to_i)
-          File.binwrite("#{staged_path}/antigravity.png", asar.read(icon_entry["size"]))
-        end
-      end
+    # ASAR uses little-endian 32-bit pickle lengths on both supported Linux CPUs.
+    if_path_exists "Antigravity/resources/app.asar" do
+      run "/bin/bash", chdir: "{{staged_path}}", env: { "JQ" => "{{HOMEBREW_PREFIX}}/bin/jq" },
+                       args: ["-euo", "pipefail", "-c", <<~'SH']
+                         asar=Antigravity/resources/app.asar
+                         header_size=$(od -An -tu4 -j4 -N4 "$asar" | tr -d '[:space:]')
+                         json_size=$(od -An -tu4 -j12 -N4 "$asar" | tr -d '[:space:]')
+                         dd if="$asar" of=asar-header.json bs=64K iflag=skip_bytes,count_bytes skip=16 count="$json_size" status=none
+                         if "$JQ" -e '.files["icon.png"] != null' asar-header.json >/dev/null; then
+                           offset=$("$JQ" -er '.files["icon.png"].offset | tonumber' asar-header.json)
+                           size=$("$JQ" -er '.files["icon.png"].size' asar-header.json)
+                           [[ "$offset" =~ ^[0-9]+$ && "$size" =~ ^[0-9]+$ ]]
+                           dd if="$asar" of=antigravity.png bs=64K iflag=skip_bytes,count_bytes \
+                             skip="$((8 + header_size + offset))" count="$size" status=none
+                         fi
+                       SH
+      remove "asar-header.json"
     end
 
-    File.write("#{staged_path}/antigravity.desktop", <<~EOS)
+    write_file "antigravity.desktop", <<~EOS
       [Desktop Entry]
       Name=Antigravity
       Comment=Agent orchestration platform
       GenericName=AI Agent Platform
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" %F
-      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
+      Exec="{{HOMEBREW_PREFIX}}/bin/antigravity" %F
+      Icon=antigravity
       Type=Application
       StartupNotify=false
       StartupWMClass=Antigravity
@@ -76,13 +73,13 @@ cask "antigravity-linux" do
       Keywords=antigravity;agent;ai;
     EOS
 
-    File.write("#{staged_path}/antigravity-url-handler.desktop", <<~EOS)
+    write_file "antigravity-url-handler.desktop", <<~EOS
       [Desktop Entry]
       Name=Antigravity - URL Handler
       Comment=Agent orchestration platform
       GenericName=AI Agent Platform
-      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" "%U"
-      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
+      Exec="{{HOMEBREW_PREFIX}}/bin/antigravity" "%U"
+      Icon=antigravity
       Type=Application
       NoDisplay=true
       Terminal=false
@@ -94,7 +91,9 @@ cask "antigravity-linux" do
     EOS
 
     # Create a placeholder icon if extraction fails
-    FileUtils.touch "#{staged_path}/antigravity.png" unless File.exist?("#{staged_path}/antigravity.png")
+    unless_path_exists "antigravity.png" do
+      touch "antigravity.png"
+    end
   end
 
   zap trash: [

--- a/Casks/asusctl-linux.rb
+++ b/Casks/asusctl-linux.rb
@@ -27,171 +27,81 @@ cask "asusctl-linux" do
     end
   end
 
-  binary "#{release_root}/usr/bin/asusctl"
-  binary "#{release_root}/usr/bin/asusd"
-  binary "#{release_root}/usr/bin/asus-shutdown"
+  binary "asusctl/usr/bin/asusctl"
+  binary "asusctl/usr/bin/asusd"
+  binary "asusctl/usr/bin/asus-shutdown"
 
-  postflight do
-    release_dir = "#{staged_path}/#{release_root}"
-    root_prefix = "/opt/ublue-asusctl"
-    root_bin_dir = "#{root_prefix}/bin"
-    root_share_dir = "#{root_prefix}/share"
-    root_asusd_dir = "#{root_share_dir}/asusd"
-    systemd_dir = "/etc/systemd/system"
-    udev_dir = "/etc/udev/rules.d"
-    dbus_dir = "/etc/dbus-1/system.d"
-    config_dir = "/etc/asusd"
-    asusd_service_src = "#{release_dir}/usr/lib/systemd/system/asusd.service"
-    asus_shutdown_service_src = "#{release_dir}/usr/lib/systemd/system/asus-shutdown.service"
-
-    getenforce = %w[/usr/sbin/getenforce /usr/bin/getenforce /bin/getenforce].find do |path|
-      File.executable?(path)
-    end
-    restorecon = %w[/usr/sbin/restorecon /usr/bin/restorecon /bin/restorecon].find do |path|
-      File.executable?(path)
-    end
-    semanage = %w[/usr/sbin/semanage /usr/bin/semanage /bin/semanage].find do |path|
-      File.executable?(path)
-    end
-    chcon = %w[/usr/sbin/chcon /usr/bin/chcon /bin/chcon].find do |path|
-      File.executable?(path)
-    end
-    systemctl = %w[/usr/bin/systemctl /bin/systemctl].find do |path|
-      File.executable?(path)
-    end
-    udevadm = %w[/usr/bin/udevadm /bin/udevadm].find do |path|
-      File.executable?(path)
-    end
-
-    ohai "Installing ASUS daemon payload under #{root_prefix}"
-
-    system "sudo", "install", "-d",
-           root_bin_dir, root_asusd_dir, systemd_dir, udev_dir, dbus_dir, config_dir
-    system "sudo", "install", "-Dm0755",
-           "#{release_dir}/usr/bin/asusd",
-           "#{root_bin_dir}/asusd"
-    system "sudo", "install", "-Dm0755",
-           "#{release_dir}/usr/bin/asus-shutdown",
-           "#{root_bin_dir}/asus-shutdown"
-    system "sudo", "cp", "-a", "#{release_dir}/usr/share/asusd/.", root_asusd_dir
-    asusd_service = File.read(asusd_service_src)
-    asusd_service.gsub!("Environment=ASUSD_EXEC=/usr/bin/asusd\n", "")
-    asusd_service.gsub!("ExecStart=${ASUSD_EXEC}", "ExecStart=#{root_bin_dir}/asusd")
-    File.write("#{staged_path}/asusd.service", asusd_service)
-
-    asus_shutdown_service = File.read(asus_shutdown_service_src)
-    asus_shutdown_service.gsub!("Environment=ASUS_SHUTDOWN_EXEC=/usr/bin/asus-shutdown\n", "")
-    asus_shutdown_service.gsub!("ExecStart=${ASUS_SHUTDOWN_EXEC}", "ExecStart=#{root_bin_dir}/asus-shutdown")
-    File.write("#{staged_path}/asus-shutdown.service", asus_shutdown_service)
-
-    system "sudo", "install", "-Dm0644",
-           "#{staged_path}/asusd.service",
-           "#{systemd_dir}/asusd.service"
-    system "sudo", "install", "-Dm0644",
-           "#{staged_path}/asus-shutdown.service",
-           "#{systemd_dir}/asus-shutdown.service"
-    system "sudo", "install", "-Dm0644",
-           "#{release_dir}/usr/lib/udev/rules.d/99-asusd.rules",
-           "#{udev_dir}/99-asusd.rules"
-    system "sudo", "install", "-Dm0644",
-           "#{release_dir}/usr/share/dbus-1/system.d/asusd.conf",
-           "#{dbus_dir}/asusd.conf"
-
-    File.write("#{staged_path}/asusd.env", <<~EOS)
-      ASUSD_DATA_DIR=#{root_asusd_dir}
-      ASUSCTL_AURA_SUPPORT_PATH=#{root_asusd_dir}/aura_support.ron
-      ASUSCTL_DATA_DIRS=#{root_share_dir}
-    EOS
-
-    system "sudo", "install", "-Dm0644",
-           "#{staged_path}/asusd.env",
-           "#{config_dir}/asusd.env"
-
-    selinux_mode = if getenforce
-      IO.popen([getenforce], &:read).strip
-    else
-      "Disabled"
-    end
-
-    if selinux_mode != "Disabled"
-      resolved_root_bin = begin
-        File.realpath(root_bin_dir)
-      rescue
-        root_bin_dir
-      end
-      bin_pattern = "#{resolved_root_bin}(/.*)?"
-
-      if semanage
-        added = system "sudo", semanage, "fcontext", "-a", "-t", "bin_t", bin_pattern
-        system "sudo", semanage, "fcontext", "-m", "-t", "bin_t", bin_pattern unless added
-      elsif chcon
-        system "sudo", chcon, "-R", "-t", "bin_t", resolved_root_bin
-      end
-
-      if restorecon
-        [root_prefix, systemd_dir, udev_dir, dbus_dir, config_dir].each do |path|
-          system "sudo", restorecon, "-RFv", path if File.exist?(path)
-        end
-      end
-    end
-
-    system "sudo", systemctl, "daemon-reload" if systemctl
-    system "sudo", udevadm, "control", "--reload" if udevadm
+  preflight_steps do
+    move "asusctl-*-ubuntu-22.04-*", "asusctl", source_glob: true
   end
 
-  uninstall_preflight do
-    root_prefix = "/opt/ublue-asusctl"
-    root_bin_dir = "#{root_prefix}/bin"
-    systemd_dir = "/etc/systemd/system"
-    udev_dir = "/etc/udev/rules.d"
-    dbus_dir = "/etc/dbus-1/system.d"
-    config_dir = "/etc/asusd"
+  postflight_steps do
+    copy "asusctl/usr/lib/systemd/system/asusd.service", "asusd.service"
+    inreplace "asusd.service", "Environment=ASUSD_EXEC=/usr/bin/asusd\n", "", audit_result: false
+    inreplace "asusd.service", "ExecStart=${ASUSD_EXEC}", "ExecStart=/opt/ublue-asusctl/bin/asusd"
+    copy "asusctl/usr/lib/systemd/system/asus-shutdown.service", "asus-shutdown.service"
+    inreplace "asus-shutdown.service", "Environment=ASUS_SHUTDOWN_EXEC=/usr/bin/asus-shutdown\n", "",
+              audit_result: false
+    inreplace "asus-shutdown.service", "ExecStart=${ASUS_SHUTDOWN_EXEC}",
+              "ExecStart=/opt/ublue-asusctl/bin/asus-shutdown"
+    write_file "asusd.env", <<~EOS
+      ASUSD_DATA_DIR=/opt/ublue-asusctl/share/asusd
+      ASUSCTL_AURA_SUPPORT_PATH=/opt/ublue-asusctl/share/asusd/aura_support.ron
+      ASUSCTL_DATA_DIRS=/opt/ublue-asusctl/share
+    EOS
+    run "/bin/sh", args: ["-eu", "-c", <<~SH, "--", "{{staged_path}}"], sudo: true
+      PATH=/usr/sbin:/usr/bin:/bin
+      stage=$1
+      root=/opt/ublue-asusctl
+      install -d "$root/bin" "$root/share/asusd" /etc/systemd/system /etc/udev/rules.d /etc/dbus-1/system.d /etc/asusd
+      install -Dm0755 "$stage/asusctl/usr/bin/asusd" "$root/bin/asusd"
+      install -Dm0755 "$stage/asusctl/usr/bin/asus-shutdown" "$root/bin/asus-shutdown"
+      cp -a "$stage/asusctl/usr/share/asusd/." "$root/share/asusd"
+      install -Dm0644 "$stage/asusd.service" /etc/systemd/system/asusd.service
+      install -Dm0644 "$stage/asus-shutdown.service" /etc/systemd/system/asus-shutdown.service
+      install -Dm0644 "$stage/asusctl/usr/lib/udev/rules.d/99-asusd.rules" /etc/udev/rules.d/99-asusd.rules
+      install -Dm0644 "$stage/asusctl/usr/share/dbus-1/system.d/asusd.conf" /etc/dbus-1/system.d/asusd.conf
+      install -Dm0644 "$stage/asusd.env" /etc/asusd/asusd.env
 
-    getenforce = %w[/usr/sbin/getenforce /usr/bin/getenforce /bin/getenforce].find do |path|
-      File.executable?(path)
-    end
-    restorecon = %w[/usr/sbin/restorecon /usr/bin/restorecon /bin/restorecon].find do |path|
-      File.executable?(path)
-    end
-    semanage = %w[/usr/sbin/semanage /usr/bin/semanage /bin/semanage].find do |path|
-      File.executable?(path)
-    end
-    systemctl = %w[/usr/bin/systemctl /bin/systemctl].find do |path|
-      File.executable?(path)
-    end
-    udevadm = %w[/usr/bin/udevadm /bin/udevadm].find do |path|
-      File.executable?(path)
-    end
+      if command -v getenforce >/dev/null && [ "$(getenforce)" != Disabled ]; then
+        resolved_bin=$(readlink -f "$root/bin")
+        if command -v semanage >/dev/null; then
+          semanage fcontext -a -t bin_t "$resolved_bin(/.*)?" || semanage fcontext -m -t bin_t "$resolved_bin(/.*)?"
+        elif command -v chcon >/dev/null; then
+          chcon -R -t bin_t "$resolved_bin"
+        fi
+        if command -v restorecon >/dev/null; then
+          restorecon -RFv "$root" /etc/systemd/system /etc/udev/rules.d /etc/dbus-1/system.d /etc/asusd
+        fi
+      fi
+      if command -v systemctl >/dev/null; then systemctl daemon-reload || true; fi
+      if command -v udevadm >/dev/null; then udevadm control --reload || true; fi
+    SH
+  end
 
-    system "sudo", systemctl, "disable", "--now", "asus-shutdown.service" if systemctl
-    system "sudo", systemctl, "disable", "--now", "asusd.service" if systemctl
-
-    selinux_mode = if getenforce
-      IO.popen([getenforce], &:read).strip
-    else
-      "Disabled"
-    end
-
-    if selinux_mode != "Disabled" && semanage
-      resolved_root_bin = begin
-        File.realpath(root_bin_dir)
-      rescue
-        root_bin_dir
-      end
-      system "sudo", semanage, "fcontext", "-d", "#{resolved_root_bin}(/.*)?"
-    end
-
-    system "sudo", "rm", "-f", "#{systemd_dir}/asusd.service"
-    system "sudo", "rm", "-f", "#{systemd_dir}/asus-shutdown.service"
-    system "sudo", "rm", "-f", "#{udev_dir}/99-asusd.rules"
-    system "sudo", "rm", "-f", "#{dbus_dir}/asusd.conf"
-    system "sudo", "rm", "-f", "#{config_dir}/asusd.env"
-    system "sudo", "rm", "-rf", root_prefix
-    system "sudo", "rmdir", config_dir if Dir.exist?(config_dir) && Dir.empty?(config_dir)
-
-    system "sudo", systemctl, "daemon-reload" if systemctl
-    system "sudo", udevadm, "control", "--reload" if udevadm
-    system "sudo", restorecon, "-RFv", "/opt", "/var/opt" if restorecon && selinux_mode != "Disabled"
+  uninstall_preflight_steps do
+    run "/bin/sh", args: ["-eu", "-c", <<~'SH'], sudo: true
+      PATH=/usr/sbin:/usr/bin:/bin
+      if command -v systemctl >/dev/null; then
+        systemctl disable --now asus-shutdown.service || true
+        systemctl disable --now asusd.service || true
+      fi
+      selinux=Disabled
+      if command -v getenforce >/dev/null; then selinux=$(getenforce); fi
+      if [ "$selinux" != Disabled ] && command -v semanage >/dev/null; then
+        resolved_bin=$(readlink -f /opt/ublue-asusctl/bin || printf /opt/ublue-asusctl/bin)
+        semanage fcontext -d "$resolved_bin(/.*)?" || true
+      fi
+      rm -f /etc/systemd/system/asusd.service /etc/systemd/system/asus-shutdown.service \
+        /etc/udev/rules.d/99-asusd.rules /etc/dbus-1/system.d/asusd.conf /etc/asusd/asusd.env
+      rm -rf /opt/ublue-asusctl
+      rmdir /etc/asusd 2>/dev/null || true
+      if command -v systemctl >/dev/null; then systemctl daemon-reload || true; fi
+      if command -v udevadm >/dev/null; then udevadm control --reload || true; fi
+      if [ "$selinux" != Disabled ] && command -v restorecon >/dev/null; then
+        restorecon -RFv /opt /var/opt || true
+      fi
+    SH
   end
 
   caveats <<~EOS

--- a/Casks/aurora-wallpapers.rb
+++ b/Casks/aurora-wallpapers.rb
@@ -13,43 +13,45 @@ cask "aurora-wallpapers" do
     strategy :github_releases
   end
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/backgrounds/aurora"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/gnome-background-properties"
-
-    Dir.glob("#{staged_path}/**/*.xml").each do |file|
-      contents = File.read(file)
-      contents.gsub!("~", Dir.home)
-      File.write(file, contents)
-    end
+  preflight_steps do
+    mkdir_p ".local/share/backgrounds/aurora", base: :home
+    mkdir_p ".local/share/gnome-background-properties", base: :home
+    symlink ".", ".user-home", source_base: :home, overwrite: true
+    run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
+      WALLPAPER_HOME=$(readlink .user-home)
+      replacement=$(printf '%s' "$WALLPAPER_HOME" | sed 's/[\\&|]/\\&/g')
+      find . -type f -name '*.xml' -exec sed -i.brew-home-backup "s|~|$replacement|g" {} +
+      find . -type f -name '*.xml.brew-home-backup' -delete
+    SH
   end
 
-  postflight do
-    if File.exist?("/usr/bin/plasmashell")
-      Dir.glob("#{staged_path}/kde/*").each do |dir|
-        next if dir.include?("gnome-background-properties")
-
-        target = "#{Dir.home}/.local/share/backgrounds/aurora/#{File.basename(dir)}"
-        FileUtils.ln_sf(dir, target)
-      end
-    else
-      Dir.glob("#{staged_path}/kde/*").each do |dir|
-        Dir.glob("#{dir}/contents/images/*").each do |file|
-          extension = File.extname(file)
-          target = "#{Dir.home}/.local/share/backgrounds/aurora/#{File.basename(dir)}#{extension}"
-          FileUtils.ln_sf(file, target)
-        end
-
-        Dir.glob("#{dir}/gnome-background-properties/*").each do |file|
-          target = "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      end
-    end
+  postflight_steps do
+    run "/bin/bash", chdir: "{{staged_path}}",
+                     env: { "WALLPAPER_HOME" => "{{staged_path}}/.user-home" },
+                     writable_paths: [".local/share/backgrounds/aurora", ".local/share/gnome-background-properties"],
+                     writable_base: :home, args: ["-eu", "-c", <<~SH]
+                       shopt -s nullglob
+                       destination="$WALLPAPER_HOME/.local/share/backgrounds/aurora"
+                       for directory in "$PWD"/kde/*; do
+                         if [ -e /usr/bin/plasmashell ]; then
+                           [[ "$directory" != *gnome-background-properties* ]] || continue
+                           ln -sfn "$directory" "$destination/$(basename "$directory")"
+                         else
+                           for file in "$directory"/contents/images/*; do
+                             filename=$(basename "$file")
+                             ln -sfn "$file" "$destination/$(basename "$directory").${filename##*.}"
+                           done
+                           for file in "$directory"/gnome-background-properties/*; do
+                             ln -sfn "$file" "$WALLPAPER_HOME/.local/share/gnome-background-properties/$(basename "$file")"
+                           done
+                         fi
+                       done
+                     SH
   end
 
-  uninstall_postflight do
-    FileUtils.rm_r "#{Dir.home}/.local/share/backgrounds/aurora"
+  uninstall_postflight_steps do
+    remove [".local/share/backgrounds/aurora/**/*", ".local/share/gnome-background-properties/*.xml"],
+           base: :home, symlink_target_contains: "/aurora-wallpapers/"
   end
 
   zap trash: [

--- a/Casks/bazzite-wallpapers.rb
+++ b/Casks/bazzite-wallpapers.rb
@@ -13,28 +13,39 @@ cask "bazzite-wallpapers" do
     strategy :github_releases
   end
 
-  destination_dir = "#{Dir.home}/.local/share/backgrounds/bazzite"
-  kde_destination_dir = "#{Dir.home}/.local/share/backgrounds/bazzite"
-
-  if File.exist?("/usr/bin/plasmashell")
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
-    end
-  else
-    Dir.glob("#{staged_path}/images/*").each do |file|
-      artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-    end
-
-    Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-      artifact file, target: "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-    end
+  preflight_steps do
+    symlink ".", ".user-home", source_base: :home, overwrite: true
+    run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
+      WALLPAPER_HOME=$(readlink .user-home)
+      replacement=$(printf '%s' "$WALLPAPER_HOME" | sed 's/[\\&|]/\\&/g')
+      find . -type f -name '*.xml' -exec sed -i.brew-home-backup "s|~|$replacement|g" {} +
+      find . -type f -name '*.xml.brew-home-backup' -delete
+    SH
   end
 
-  preflight do
-    Dir.glob("#{staged_path}/**/*.xml").each do |file|
-      contents = File.read(file)
-      contents.gsub!("~", Dir.home)
-      File.write(file, contents)
-    end
+  postflight_steps do
+    mkdir_p ".local/share/backgrounds/bazzite", base: :home
+    mkdir_p ".local/share/gnome-background-properties", base: :home
+    # Discover the payload after extraction, not while loading the cask for CI/API use.
+    run "/bin/bash", chdir: "{{staged_path}}",
+                     env: { "WALLPAPER_HOME" => "{{staged_path}}/.user-home" },
+                     writable_paths: [".local/share/backgrounds/bazzite", ".local/share/gnome-background-properties"],
+                     writable_base: :home, args: ["-eu", "-c", <<~SH]
+                       shopt -s nullglob
+                       destination="$WALLPAPER_HOME/.local/share/backgrounds/bazzite"
+                       if [ -e /usr/bin/plasmashell ]; then
+                         for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                       else
+                         for file in "$PWD"/images/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         for file in "$PWD"/gnome-background-properties/*; do
+                           ln -sfn "$file" "$WALLPAPER_HOME/.local/share/gnome-background-properties/$(basename "$file")"
+                         done
+                       fi
+                     SH
+  end
+
+  uninstall_postflight_steps do
+    remove [".local/share/backgrounds/bazzite/**/*", ".local/share/gnome-background-properties/*.xml"],
+           base: :home, symlink_target_contains: "/bazzite-wallpapers/"
   end
 end

--- a/Casks/bluefin-wallpapers-extra.rb
+++ b/Casks/bluefin-wallpapers-extra.rb
@@ -31,95 +31,66 @@ cask "bluefin-wallpapers-extra" do
     strategy :github_releases
   end
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra" if OS.mac?
-
-    if OS.linux?
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/backgrounds/bluefin"
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/wallpapers/bluefin"
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/gnome-background-properties"
-
-      Dir.glob("#{staged_path}/**/*.xml").each do |file|
-        contents = File.read(file)
-        contents.gsub!("~", Dir.home)
-        File.write(file, contents)
-      end
+  preflight_steps do
+    on_linux do
+      symlink ".", ".user-home", source_base: :home, overwrite: true
+      run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
+        WALLPAPER_HOME=$(readlink .user-home)
+        replacement=$(printf '%s' "$WALLPAPER_HOME" | sed 's/[\\&|]/\\&/g')
+        find . -type f -name '*.xml' -exec sed -i.brew-home-backup "s|~|$replacement|g" {} +
+        find . -type f -name '*.xml.brew-home-backup' -delete
+      SH
     end
   end
 
-  postflight do
-    if OS.mac?
-      Dir.glob("#{staged_path}/*").each do |file|
-        target = "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra/#{File.basename(file)}"
-        FileUtils.ln_sf(file, target)
-      end
-      puts "Wallpapers installed to: #{Dir.home}/Library/Desktop Pictures/Bluefin-Extra"
-      puts "To use: System Settings > Wallpaper > Add Folder"
+  postflight_steps do
+    on_macos do
+      mkdir_p "Library/Desktop Pictures/Bluefin-Extra", base: :home
+      symlink "*", "Library/Desktop Pictures/Bluefin-Extra", target_base: :home, source_glob: true, overwrite: true
     end
-
-    if OS.linux?
-      destination_dir = "#{Dir.home}/.local/share/backgrounds/bluefin"
-      kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/bluefin"
-
-      if File.exist?("/usr/bin/plasmashell")
-        Dir.glob("#{staged_path}/*").each do |file|
-          target = "#{kde_destination_dir}/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
-        Dir.glob("#{staged_path}/images/*").each do |file|
-          folder = File.basename(file, File.extname(file)).gsub(/-night|-day/, "")
-          FileUtils.mkdir_p "#{destination_dir}/#{folder}"
-          target = "#{destination_dir}/#{folder}/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-
-        Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-          target = "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      else
-        Dir.glob("#{staged_path}/*").each do |file|
-          target = "#{destination_dir}/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      end
+    on_linux do
+      mkdir_p ".local/share/backgrounds/bluefin", base: :home
+      mkdir_p ".local/share/wallpapers/bluefin", base: :home
+      mkdir_p ".local/share/gnome-background-properties", base: :home
+      run "/bin/bash", chdir: "{{staged_path}}",
+                       env: { "WALLPAPER_HOME" => "{{staged_path}}/.user-home" },
+                       writable_paths: [".local/share/backgrounds/bluefin", ".local/share/wallpapers/bluefin",
+                                        ".local/share/gnome-background-properties"], writable_base: :home,
+                       args: ["-eu", "-c", <<~SH]
+                         shopt -s nullglob
+                         destination="$WALLPAPER_HOME/.local/share/backgrounds/bluefin"
+                         if [ -e /usr/bin/plasmashell ]; then
+                           destination="$WALLPAPER_HOME/.local/share/wallpapers/bluefin"
+                           for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         elif [ -e /usr/bin/gnome-shell ] || [ -e /usr/bin/mutter ]; then
+                           for file in "$PWD"/images/*; do
+                             filename=$(basename "$file")
+                             folder=${filename%.*}
+                             folder=${folder//-night/}
+                             folder=${folder//-day/}
+                             mkdir -p "$destination/$folder"
+                             ln -sfn "$file" "$destination/$folder/$filename"
+                           done
+                           for file in "$PWD"/gnome-background-properties/*; do
+                             ln -sfn "$file" "$WALLPAPER_HOME/.local/share/gnome-background-properties/$(basename "$file")"
+                           done
+                         else
+                           for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         fi
+                       SH
     end
   end
 
-  uninstall_postflight do
-    FileUtils.rm_r "#{Dir.home}/Library/Desktop Pictures/Bluefin-Extra" if OS.mac?
-
-    if OS.linux?
-      bg_dir    = "#{Dir.home}/.local/share/backgrounds/bluefin"
-      kde_dir   = "#{Dir.home}/.local/share/wallpapers/bluefin"
-      props_dir = "#{Dir.home}/.local/share/gnome-background-properties"
-
-      # Remove only the symlinks this cask created via postflight. During upgrade,
-      # these point to the old staged path (now being removed) and become broken.
-      # Symlinks from bluefin-wallpapers point to a separate Caskroom path that is
-      # not being removed, so they remain valid and are intentionally left alone.
-      [bg_dir, kde_dir].each do |dir|
-        next unless Dir.exist?(dir)
-
-        Dir.glob("#{dir}/**/*").reverse_each do |f|
-          File.unlink(f) if File.symlink?(f) && !File.exist?(f)
-          next unless File.directory?(f)
-          next unless Dir.empty?(f)
-
-          begin
-            Dir.rmdir(f)
-          rescue
-            nil
-          end
-        end
-      end
-
-      if Dir.exist?(props_dir)
-        Dir.glob("#{props_dir}/*.xml").each do |f|
-          File.unlink(f) if File.symlink?(f) && !File.exist?(f)
-        end
-      end
+  uninstall_postflight_steps do
+    on_macos do
+      remove "Library/Desktop Pictures/Bluefin-Extra/*", base:                    :home,
+                                                         symlink_target_contains: "/bluefin-wallpapers-extra/"
+    end
+    on_linux do
+      # The main and extra casks share destinations; never remove the other cask's links.
+      remove [".local/share/backgrounds/bluefin/**/*", ".local/share/wallpapers/bluefin/**/*",
+              ".local/share/gnome-background-properties/*.xml"],
+             base: :home, symlink_target_contains: "/bluefin-wallpapers-extra/"
     end
   end
 

--- a/Casks/bluefin-wallpapers.rb
+++ b/Casks/bluefin-wallpapers.rb
@@ -7,40 +7,20 @@ cask "bluefin-wallpapers" do
     sha256 "afafb174f8d16b374ed1bf467b0c688f2e27fd49c44c5e4aba743c36b2b5fa1a"
 
     url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-macos.tar.zstd"
-
-    Dir.glob("#{staged_path}/*").each do |file|
-      artifact file, target: "#{Dir.home}/Library/Desktop Pictures/Bluefin/#{File.basename(file)}"
-    end
   end
   on_linux do
-    destination_dir = "#{Dir.home}/.local/share/backgrounds/bluefin"
-    kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/bluefin"
-
     if File.exist?("/usr/bin/plasmashell")
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-kde.tar.zstd"
       sha256 "d1c3b022e5ff0532e2727de76bc9bc8fb2efb74c6201c4d1cda55dbbc3826be9"
 
-      Dir.glob("#{staged_path}/*").each do |file|
-        artifact file, target: "#{kde_destination_dir}/#{File.basename(file)}"
-      end
     elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-gnome.tar.zstd"
       sha256 "b3c5332f28c06265aa39284c0e1fad5ec970860d06737ebae24072a17cb52bf4"
 
-      Dir.glob("#{staged_path}/*").select { |f| File.file?(f) }.each do |file|
-        artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-      end
-
-      Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-        artifact file, target: "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-      end
     else
       url "https://github.com/ublue-os/artwork/releases/download/bluefin-v#{version}/bluefin-wallpapers-png.tar.zstd"
       sha256 "52cce2d24ef1df7978b432c5f248322af27b416efa334e854f57fc9f99decb51"
 
-      Dir.glob("#{staged_path}/*").each do |file|
-        artifact file, target: "#{destination_dir}/#{File.basename(file)}"
-      end
     end
   end
 
@@ -54,26 +34,63 @@ cask "bluefin-wallpapers" do
     strategy :github_releases
   end
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/Library/Desktop Pictures/Bluefin" if OS.mac?
-
-    if OS.linux?
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/backgrounds/bluefin"
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/wallpapers/bluefin"
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/gnome-background-properties"
-
-      Dir.glob("#{staged_path}/**/*.xml").each do |file|
-        contents = File.read(file)
-        contents.gsub!("~", Dir.home)
-        File.write(file, contents)
-      end
+  preflight_steps do
+    on_linux do
+      symlink ".", ".user-home", source_base: :home, overwrite: true
+      run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
+        WALLPAPER_HOME=$(readlink .user-home)
+        replacement=$(printf '%s' "$WALLPAPER_HOME" | sed 's/[\\&|]/\\&/g')
+        find . -type f -name '*.xml' -exec sed -i.brew-home-backup "s|~|$replacement|g" {} +
+        find . -type f -name '*.xml.brew-home-backup' -delete
+      SH
     end
   end
 
-  postflight do
-    if OS.mac?
-      puts "Wallpapers installed to: #{Dir.home}/Library/Desktop Pictures/Bluefin"
-      puts "To use: System Settings > Wallpaper > Add Folder"
+  postflight_steps do
+    on_macos do
+      mkdir_p "Library/Desktop Pictures/Bluefin", base: :home
+      symlink "*", "Library/Desktop Pictures/Bluefin", target_base: :home, source_glob: true, overwrite: true
+    end
+    on_linux do
+      mkdir_p ".local/share/backgrounds/bluefin", base: :home
+      mkdir_p ".local/share/wallpapers/bluefin", base: :home
+      mkdir_p ".local/share/gnome-background-properties", base: :home
+      run "/bin/bash", chdir: "{{staged_path}}",
+                       env: { "WALLPAPER_HOME" => "{{staged_path}}/.user-home" },
+                       writable_paths: [".local/share/backgrounds/bluefin", ".local/share/wallpapers/bluefin",
+                                        ".local/share/gnome-background-properties"], writable_base: :home,
+                       args: ["-eu", "-c", <<~SH]
+                         shopt -s nullglob
+                         destination="$WALLPAPER_HOME/.local/share/backgrounds/bluefin"
+                         if [ -e /usr/bin/plasmashell ]; then
+                           destination="$WALLPAPER_HOME/.local/share/wallpapers/bluefin"
+                           for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         elif [ -e /usr/bin/gnome-shell ] || [ -e /usr/bin/mutter ]; then
+                           for file in "$PWD"/*; do
+                             if [ -f "$file" ]; then ln -sfn "$file" "$destination/$(basename "$file")"; fi
+                           done
+                           for file in "$PWD"/gnome-background-properties/*; do
+                             ln -sfn "$file" "$WALLPAPER_HOME/.local/share/gnome-background-properties/$(basename "$file")"
+                           done
+                         else
+                           for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         fi
+                       SH
     end
   end
+
+  uninstall_postflight_steps do
+    on_macos do
+      remove "Library/Desktop Pictures/Bluefin/*", base: :home, symlink_target_contains: "/bluefin-wallpapers/"
+    end
+    on_linux do
+      remove [".local/share/backgrounds/bluefin/**/*", ".local/share/wallpapers/bluefin/**/*",
+              ".local/share/gnome-background-properties/*.xml"],
+             base: :home, symlink_target_contains: "/bluefin-wallpapers/"
+    end
+  end
+
+  caveats <<~EOS
+    On macOS, add ~/Library/Desktop Pictures/Bluefin in System Settings > Wallpaper > Add Folder.
+  EOS
 end

--- a/Casks/framework-wallpapers.rb
+++ b/Casks/framework-wallpapers.rb
@@ -31,66 +31,57 @@ cask "framework-wallpapers" do
     strategy :github_releases
   end
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/Library/Desktop Pictures/Framework" if OS.mac?
-
-    if OS.linux?
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/backgrounds/framework"
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/wallpapers/framework"
-      FileUtils.mkdir_p "#{Dir.home}/.local/share/gnome-background-properties"
-
-      Dir.glob("#{staged_path}/**/*.xml").each do |file|
-        contents = File.read(file)
-        contents.gsub!("~", Dir.home)
-        File.write(file, contents)
-      end
+  preflight_steps do
+    on_linux do
+      symlink ".", ".user-home", source_base: :home, overwrite: true
+      run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
+        WALLPAPER_HOME=$(readlink .user-home)
+        replacement=$(printf '%s' "$WALLPAPER_HOME" | sed 's/[\\&|]/\\&/g')
+        find . -type f -name '*.xml' -exec sed -i.brew-home-backup "s|~|$replacement|g" {} +
+        find . -type f -name '*.xml.brew-home-backup' -delete
+      SH
     end
   end
 
-  postflight do
-    if OS.mac?
-      Dir.glob("#{staged_path}/*").each do |file|
-        target = "#{Dir.home}/Library/Desktop Pictures/Framework/#{File.basename(file)}"
-        FileUtils.ln_sf(file, target)
-      end
-      puts "Wallpapers installed to: #{Dir.home}/Library/Desktop Pictures/Framework"
-      puts "To use: System Settings > Wallpaper > Add Folder"
+  postflight_steps do
+    on_macos do
+      mkdir_p "Library/Desktop Pictures/Framework", base: :home
+      symlink "*", "Library/Desktop Pictures/Framework", target_base: :home, source_glob: true, overwrite: true
     end
-
-    if OS.linux?
-      destination_dir = "#{Dir.home}/.local/share/backgrounds/framework"
-      kde_destination_dir = "#{Dir.home}/.local/share/wallpapers/framework"
-
-      if File.exist?("/usr/bin/plasmashell")
-        Dir.glob("#{staged_path}/*").each do |file|
-          target = "#{kde_destination_dir}/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      elsif File.exist?("/usr/bin/gnome-shell") || File.exist?("/usr/bin/mutter")
-        Dir.glob("#{staged_path}/images/*").each do |file|
-          target = "#{destination_dir}/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-
-        Dir.glob("#{staged_path}/gnome-background-properties/*").each do |file|
-          target = "#{Dir.home}/.local/share/gnome-background-properties/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      else
-        Dir.glob("#{staged_path}/*").each do |file|
-          target = "#{destination_dir}/#{File.basename(file)}"
-          FileUtils.ln_sf(file, target)
-        end
-      end
+    on_linux do
+      mkdir_p ".local/share/backgrounds/framework", base: :home
+      mkdir_p ".local/share/wallpapers/framework", base: :home
+      mkdir_p ".local/share/gnome-background-properties", base: :home
+      run "/bin/bash", chdir: "{{staged_path}}",
+                       env: { "WALLPAPER_HOME" => "{{staged_path}}/.user-home" },
+                       writable_paths: [".local/share/backgrounds/framework", ".local/share/wallpapers/framework",
+                                        ".local/share/gnome-background-properties"], writable_base: :home,
+                       args: ["-eu", "-c", <<~SH]
+                         shopt -s nullglob
+                         destination="$WALLPAPER_HOME/.local/share/backgrounds/framework"
+                         if [ -e /usr/bin/plasmashell ]; then
+                           destination="$WALLPAPER_HOME/.local/share/wallpapers/framework"
+                           for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         elif [ -e /usr/bin/gnome-shell ] || [ -e /usr/bin/mutter ]; then
+                           for file in "$PWD"/images/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                           for file in "$PWD"/gnome-background-properties/*; do
+                             ln -sfn "$file" "$WALLPAPER_HOME/.local/share/gnome-background-properties/$(basename "$file")"
+                           done
+                         else
+                           for file in "$PWD"/*; do ln -sfn "$file" "$destination/$(basename "$file")"; done
+                         fi
+                       SH
     end
   end
 
-  uninstall_postflight do
-    FileUtils.rm_r "#{Dir.home}/Library/Desktop Pictures/Framework" if OS.mac?
-
-    if OS.linux?
-      FileUtils.rm_r "#{Dir.home}/.local/share/backgrounds/framework"
-      FileUtils.rm_r "#{Dir.home}/.local/share/wallpapers/framework"
+  uninstall_postflight_steps do
+    on_macos do
+      remove "Library/Desktop Pictures/Framework/*", base: :home, symlink_target_contains: "/framework-wallpapers/"
+    end
+    on_linux do
+      remove [".local/share/backgrounds/framework/**/*", ".local/share/wallpapers/framework/**/*",
+              ".local/share/gnome-background-properties/*.xml"],
+             base: :home, symlink_target_contains: "/framework-wallpapers/"
     end
   end
 

--- a/Casks/jetbrains-toolbox-linux.rb
+++ b/Casks/jetbrains-toolbox-linux.rb
@@ -19,15 +19,15 @@ cask "jetbrains-toolbox-linux" do
   artifact "jetbrains-toolbox-#{version}/jetbrains-toolbox.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-toolbox.desktop"
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+  preflight_steps do
+    mkdir_p ".local/share/applications", base: :home
     # We need this file to start, but Jetbrains Toolbox will overwrite it on its first run with a proper one
     # It will also extract the icon from somewhere, but it doesn't exist until first run, so we just point to where it
     # should be, and it will get fixed on first run
-    File.write("#{staged_path}/jetbrains-toolbox-#{version}/jetbrains-toolbox.desktop", <<~EOS)
+    write_file "jetbrains-toolbox-{{version}}/jetbrains-toolbox.desktop", <<~EOS
       [Desktop Entry]
-      Icon=#{staged_path}/jetbrains-toolbox-#{version}/bin/toolbox-tray-color.png
-      Exec=#{HOMEBREW_PREFIX}/bin/jetbrains-toolbox %u
+      Icon={{staged_path}}/jetbrains-toolbox-{{version}}/bin/toolbox-tray-color.png
+      Exec={{HOMEBREW_PREFIX}}/bin/jetbrains-toolbox %u
       Version=1.0
       Type=Application
       Categories=Development

--- a/Casks/lm-studio-linux.rb
+++ b/Casks/lm-studio-linux.rb
@@ -26,21 +26,14 @@ cask "lm-studio-linux" do
   artifact "squashfs-root/ai.elementlabs.lmstudio.desktop",
            target: "#{Dir.home}/.local/share/applications/lm-studio.desktop"
 
-  preflight do
-    # Extract AppImage contents
-    appimage_path = "#{staged_path}/LM-Studio-#{version}-x64.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
-
-    # Remove the original AppImage to save space
-    FileUtils.rm appimage_path
-
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons"
-
-    desktop_content = File.read("#{staged_path}/squashfs-root/ai.elementlabs.lmstudio.desktop")
-    desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/lm-studio")
-    File.write("#{staged_path}/squashfs-root/ai.elementlabs.lmstudio.desktop", desktop_content)
+  preflight_steps do
+    set_permissions "LM-Studio-{{version}}-x64.AppImage", "+x", recursive: false
+    run "LM-Studio-{{version}}-x64.AppImage", args: ["--appimage-extract"],
+                                           base: :staged_path, chdir: "{{staged_path}}"
+    remove "LM-Studio-{{version}}-x64.AppImage"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons", base: :home
+    inreplace "squashfs-root/ai.elementlabs.lmstudio.desktop", /^Exec=.*/, "Exec={{HOMEBREW_PREFIX}}/bin/lm-studio"
   end
 
   zap trash: "~/.config/LMStudio"

--- a/Casks/rog-control-center-linux.rb
+++ b/Casks/rog-control-center-linux.rb
@@ -27,125 +27,73 @@ cask "rog-control-center-linux" do
     end
   end
 
-  binary "#{release_root}/usr/bin/rog-control-center"
-  binary "#{release_root}/usr/bin/asusd-user"
+  binary "asusctl/usr/bin/rog-control-center"
+  binary "asusctl/usr/bin/asusd-user"
 
-  postflight do
-    require "fileutils"
-
-    release_dir = "#{staged_path}/#{release_root}"
-    xdg_share = "#{Dir.home}/.local/share"
-    xdg_config = "#{Dir.home}/.config"
-    applications_dir = "#{xdg_share}/applications"
-    icons_dir = "#{xdg_share}/icons/hicolor/512x512/apps"
-    status_icons_dir = "#{xdg_share}/icons/hicolor/scalable/status"
-    asusd_share_dir = "#{xdg_share}/asusd"
-    rog_gui_share_dir = "#{xdg_share}/rog-gui"
-    systemd_user_dir = "#{xdg_config}/systemd/user"
-    asusd_config_dir = "#{xdg_config}/asusd"
-    asusd_user_service_src = "#{release_dir}/usr/lib/systemd/user/asusd-user.service"
-
-    icon_cache_cmd = system("which gtk-update-icon-cache > /dev/null 2>&1")
-    desktop_db_cmd = system("which update-desktop-database > /dev/null 2>&1")
-
-    FileUtils.mkdir_p(
-      [
-        applications_dir,
-        icons_dir,
-        status_icons_dir,
-        asusd_share_dir,
-        rog_gui_share_dir,
-        systemd_user_dir,
-        asusd_config_dir,
-      ],
-    )
-
-    FileUtils.cp_r("#{release_dir}/usr/share/asusd/.", asusd_share_dir)
-    FileUtils.cp_r("#{release_dir}/usr/share/rog-gui/.", rog_gui_share_dir)
-    Dir.glob("#{release_dir}/usr/share/icons/hicolor/512x512/apps/*.png").each do |icon|
-      FileUtils.cp(icon, icons_dir)
-    end
-    Dir.glob("#{release_dir}/usr/share/icons/hicolor/scalable/status/*.svg").each do |icon|
-      FileUtils.cp(icon, status_icons_dir)
-    end
-
-    desktop_contents = File.read(
-      "#{release_dir}/usr/share/applications/rog-control-center.desktop",
-    )
-    desktop_contents.gsub!(
-      /^Exec=.*/,
-      "Exec=#{HOMEBREW_PREFIX}/bin/rog-control-center",
-    )
-    File.write("#{applications_dir}/rog-control-center.desktop", desktop_contents)
-
-    asusd_user_service = File.read(asusd_user_service_src)
-    asusd_user_service.gsub!("Environment=ASUSD_USER_EXEC=/usr/bin/asusd-user\n", "")
-    asusd_user_service.gsub!(
-      "ExecStart=${ASUSD_USER_EXEC}",
-      "ExecStart=#{HOMEBREW_PREFIX}/bin/asusd-user",
-    )
-    File.write("#{systemd_user_dir}/asusd-user.service", asusd_user_service)
-
-    File.write("#{asusd_config_dir}/asusd-user.env", <<~EOS)
-      ASUSD_DATA_DIR=#{asusd_share_dir}
-      ROG_GUI_DATA_DIR=#{rog_gui_share_dir}
-      ROG_GUI_LAYOUTS_DIR=#{rog_gui_share_dir}/layouts
-      ASUSCTL_AURA_SUPPORT_PATH=#{asusd_share_dir}/aura_support.ron
-      ASUSCTL_DATA_DIRS=#{xdg_share}
-    EOS
-
-    system "gtk-update-icon-cache", "#{xdg_share}/icons/hicolor", "-f", "-t" if icon_cache_cmd
-    system "update-desktop-database", applications_dir if desktop_db_cmd
+  preflight_steps do
+    move "asusctl-*-ubuntu-22.04-*", "asusctl", source_glob: true
   end
 
-  uninstall_postflight do
-    require "fileutils"
+  postflight_steps do
+    symlink ".", ".user-home", source_base: :home, overwrite: true
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/status", base: :home
+    mkdir_p ".local/share/asusd", base: :home
+    mkdir_p ".local/share/rog-gui", base: :home
+    mkdir_p ".config/systemd/user", base: :home
+    mkdir_p ".config/asusd", base: :home
+    copy "asusctl/usr/share/asusd/.", ".local/share/asusd", target_base: :home, recursive: true
+    copy "asusctl/usr/share/rog-gui/.", ".local/share/rog-gui", target_base: :home, recursive: true
+    copy "asusctl/usr/share/icons/hicolor/512x512/apps/*.png", ".local/share/icons/hicolor/512x512/apps",
+         target_base: :home, source_glob: true
+    copy "asusctl/usr/share/icons/hicolor/scalable/status/*.svg", ".local/share/icons/hicolor/scalable/status",
+         target_base: :home, source_glob: true
+    copy "asusctl/usr/share/applications/rog-control-center.desktop",
+         ".local/share/applications/rog-control-center.desktop", target_base: :home
+    inreplace ".local/share/applications/rog-control-center.desktop", /^Exec=.*/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/rog-control-center", base: :home
+    copy "asusctl/usr/lib/systemd/user/asusd-user.service", ".config/systemd/user/asusd-user.service",
+         target_base: :home
+    inreplace ".config/systemd/user/asusd-user.service", "Environment=ASUSD_USER_EXEC=/usr/bin/asusd-user\n", "",
+              base: :home, audit_result: false
+    inreplace ".config/systemd/user/asusd-user.service", "ExecStart=${ASUSD_USER_EXEC}",
+              "ExecStart={{HOMEBREW_PREFIX}}/bin/asusd-user", base: :home
+    run "/bin/sh", chdir: "{{staged_path}}", writable_paths: [".config/asusd"], writable_base: :home,
+                   args: ["-eu", "-c", <<~SH]
+                     user_home=$(readlink .user-home)
+                     printf '%s\\n' "ASUSD_DATA_DIR=$user_home/.local/share/asusd" \
+                       "ROG_GUI_DATA_DIR=$user_home/.local/share/rog-gui" \
+                       "ROG_GUI_LAYOUTS_DIR=$user_home/.local/share/rog-gui/layouts" \
+                       "ASUSCTL_AURA_SUPPORT_PATH=$user_home/.local/share/asusd/aura_support.ron" \
+                       "ASUSCTL_DATA_DIRS=$user_home/.local/share" > .user-home/.config/asusd/asusd-user.env
+                   SH
+    run "gtk-update-icon-cache", args: ["{{staged_path}}/.user-home/.local/share/icons/hicolor", "-f", "-t"],
+                                 must_succeed: false,
+                                 writable_paths: [".local/share/icons/hicolor"], writable_base: :home
+    run "update-desktop-database", args: ["{{staged_path}}/.user-home/.local/share/applications"],
+                                   must_succeed: false,
+                                   writable_paths: [".local/share/applications"], writable_base: :home
+  end
 
-    applications_dir = "#{Dir.home}/.local/share/applications"
-    icons_dir = "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
-    status_icons_dir = "#{Dir.home}/.local/share/icons/hicolor/scalable/status"
-    systemd_user_dir = "#{Dir.home}/.config/systemd/user"
-    asusd_config_dir = "#{Dir.home}/.config/asusd"
-
-    icon_cache_cmd = system("which gtk-update-icon-cache > /dev/null 2>&1")
-    desktop_db_cmd = system("which update-desktop-database > /dev/null 2>&1")
-    systemctl = %w[/usr/bin/systemctl /bin/systemctl].find do |path|
-      File.executable?(path)
-    end
-
-    system systemctl, "--user", "disable", "--now", "asusd-user.service" if systemctl
-
-    FileUtils.rm("#{systemd_user_dir}/asusd-user.service", force: true)
-    FileUtils.rm("#{applications_dir}/rog-control-center.desktop", force: true)
-    FileUtils.rm("#{asusd_config_dir}/asusd-user.env", force: true)
-
-    %w[
-      asus_notif_blue.png
-      asus_notif_green.png
-      asus_notif_orange.png
-      asus_notif_red.png
-      asus_notif_white.png
-      asus_notif_yellow.png
-      rog-control-center.png
-    ].each do |icon|
-      FileUtils.rm("#{icons_dir}/#{icon}", force: true)
-    end
-
-    %w[
-      gpu-compute.svg
-      gpu-hybrid.svg
-      gpu-integrated.svg
-      gpu-nvidia.svg
-      gpu-vfio.svg
-      notification-reboot.svg
-    ].each do |icon|
-      FileUtils.rm("#{status_icons_dir}/#{icon}", force: true)
-    end
-
-    FileUtils.rmdir(asusd_config_dir) if Dir.exist?(asusd_config_dir) && Dir.empty?(asusd_config_dir)
-
-    system "gtk-update-icon-cache", "#{Dir.home}/.local/share/icons/hicolor", "-f", "-t" if icon_cache_cmd
-    system "update-desktop-database", applications_dir if desktop_db_cmd
+  uninstall_postflight_steps do
+    symlink ".", ".user-home", source_base: :home, overwrite: true
+    run "systemctl", args: ["--user", "disable", "--now", "asusd-user.service"], must_succeed: false,
+                     writable_paths: [".config/systemd/user"], writable_base: :home
+    remove [".config/systemd/user/asusd-user.service", ".local/share/applications/rog-control-center.desktop",
+            ".config/asusd/asusd-user.env"], base: :home
+    remove [".local/share/icons/hicolor/512x512/apps/asus_notif_{blue,green,orange,red,white,yellow}.png",
+            ".local/share/icons/hicolor/512x512/apps/rog-control-center.png",
+            ".local/share/icons/hicolor/scalable/status/gpu-{compute,hybrid,integrated,nvidia,vfio}.svg",
+            ".local/share/icons/hicolor/scalable/status/notification-reboot.svg"], base: :home
+    run "/bin/rmdir", args: ["{{staged_path}}/.user-home/.config/asusd"], must_succeed: false, print_stderr: false,
+                      writable_paths: [".config/asusd"], writable_base: :home
+    run "gtk-update-icon-cache", args: ["{{staged_path}}/.user-home/.local/share/icons/hicolor", "-f", "-t"],
+                                 must_succeed: false,
+                                 writable_paths: [".local/share/icons/hicolor"], writable_base: :home
+    run "update-desktop-database", args: ["{{staged_path}}/.user-home/.local/share/applications"],
+                                   must_succeed: false,
+                                   writable_paths: [".local/share/applications"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -21,32 +21,34 @@ cask "visual-studio-code-linux" do
     end
   end
 
-  binary "VSCode-linux-#{arch}/bin/code"
-  binary "VSCode-linux-#{arch}/bin/code-tunnel"
-  bash_completion "#{staged_path}/VSCode-linux-#{arch}/resources/completions/bash/code"
-  zsh_completion  "#{staged_path}/VSCode-linux-#{arch}/resources/completions/zsh/_code"
-  artifact "VSCode-linux-#{arch}/code.desktop",
+  depends_on formula: "jq"
+
+  binary "vscode/bin/code"
+  binary "vscode/bin/code-tunnel"
+  bash_completion "vscode/resources/completions/bash/code"
+  zsh_completion  "vscode/resources/completions/zsh/_code"
+  artifact "vscode/code.desktop",
            target: "#{Dir.home}/.local/share/applications/code.desktop"
-  artifact "VSCode-linux-#{arch}/code-url-handler.desktop",
+  artifact "vscode/code-url-handler.desktop",
            target: "#{Dir.home}/.local/share/applications/code-url-handler.desktop"
 
-  preflight do
-    # Disable VS Code's built-in update checks; Homebrew manages this install.
-    product_json = "#{staged_path}/VSCode-linux-#{arch}/resources/app/product.json"
-    product = JSON.parse(File.read(product_json))
-    product.delete("updateUrl")
-    product["configurationDefaults"] ||= {}
-    product["configurationDefaults"]["update.mode"] = "none"
-    File.write(product_json, JSON.pretty_generate(product))
+  preflight_steps do
+    move "VSCode-linux-*", "vscode", source_glob: true
+    # Parse JSON rather than relying on the upstream file's formatting.
+    run "{{HOMEBREW_PREFIX}}/bin/jq",
+        args:        ["del(.updateUrl) | .configurationDefaults[\"update.mode\"] = \"none\"",
+                      "{{staged_path}}/vscode/resources/app/product.json"],
+        stdout_path: "product.json"
+    move "product.json", "vscode/resources/app/product.json"
 
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    File.write("#{staged_path}/VSCode-linux-#{arch}/code.desktop", <<~EOS)
+    mkdir_p ".local/share/applications", base: :home
+    write_file "vscode/code.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code
       Comment=Code Editing. Redefined.
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/code %F
-      Icon=#{staged_path}/VSCode-linux-#{arch}/resources/app/resources/linux/code.png
+      Exec={{HOMEBREW_PREFIX}}/bin/code %F
+      Icon={{staged_path}}/vscode/resources/app/resources/linux/code.png
       Type=Application
       StartupNotify=false
       StartupWMClass=Code
@@ -67,16 +69,16 @@ cask "visual-studio-code-linux" do
       Name[ru]=Новое пустое окно
       Name[zh_CN]=新建空窗口
       Name[zh_TW]=開新空視窗
-      Exec=#{HOMEBREW_PREFIX}/bin/code --new-window %F
-      Icon=#{staged_path}/VSCode-linux-#{arch}/resources/app/resources/linux/code.png
+      Exec={{HOMEBREW_PREFIX}}/bin/code --new-window %F
+      Icon={{staged_path}}/vscode/resources/app/resources/linux/code.png
     EOS
-    File.write("#{staged_path}/VSCode-linux-#{arch}/code-url-handler.desktop", <<~EOS)
+    write_file "vscode/code-url-handler.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code - URL Handler
       Comment=Code Editing. Redefined.
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/code --open-url %U
-      Icon=#{staged_path}/VSCode-linux-#{arch}/resources/app/resources/linux/code.png
+      Exec={{HOMEBREW_PREFIX}}/bin/code --open-url %U
+      Icon={{staged_path}}/vscode/resources/app/resources/linux/code.png
       Type=Application
       NoDisplay=true
       StartupNotify=true

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -25,32 +25,33 @@ cask "visual-studio-code-linux@insiders" do
     end
   end
 
-  binary "VSCode-linux-#{arch}/bin/code-insiders"
-  binary "VSCode-linux-#{arch}/bin/code-tunnel-insiders"
-  bash_completion "#{staged_path}/VSCode-linux-#{arch}/resources/completions/bash/code-insiders"
-  zsh_completion  "#{staged_path}/VSCode-linux-#{arch}/resources/completions/zsh/_code-insiders"
-  artifact "VSCode-linux-#{arch}/code-insiders.desktop",
+  depends_on formula: "jq"
+
+  binary "vscode-insiders/bin/code-insiders"
+  binary "vscode-insiders/bin/code-tunnel-insiders"
+  bash_completion "vscode-insiders/resources/completions/bash/code-insiders"
+  zsh_completion  "vscode-insiders/resources/completions/zsh/_code-insiders"
+  artifact "vscode-insiders/code-insiders.desktop",
            target: "#{Dir.home}/.local/share/applications/code-insiders.desktop"
-  artifact "VSCode-linux-#{arch}/code-insiders-url-handler.desktop",
+  artifact "vscode-insiders/code-insiders-url-handler.desktop",
            target: "#{Dir.home}/.local/share/applications/code-insiders-url-handler.desktop"
 
-  preflight do
-    # Disable VS Code's built-in update checks; Homebrew manages this install.
-    product_json = "#{staged_path}/VSCode-linux-#{arch}/resources/app/product.json"
-    product = JSON.parse(File.read(product_json))
-    product.delete("updateUrl")
-    product["configurationDefaults"] ||= {}
-    product["configurationDefaults"]["update.mode"] = "none"
-    File.write(product_json, JSON.pretty_generate(product))
+  preflight_steps do
+    move "VSCode-linux-*", "vscode-insiders", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/bin/jq",
+        args:        ["del(.updateUrl) | .configurationDefaults[\"update.mode\"] = \"none\"",
+                      "{{staged_path}}/vscode-insiders/resources/app/product.json"],
+        stdout_path: "product.json"
+    move "product.json", "vscode-insiders/resources/app/product.json"
 
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    File.write("#{staged_path}/VSCode-linux-#{arch}/code-insiders.desktop", <<~EOS)
+    mkdir_p ".local/share/applications", base: :home
+    write_file "vscode-insiders/code-insiders.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code - Insiders
       Comment=Code Editing. Redefined.
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/code-insiders %F
-      Icon=#{staged_path}/VSCode-linux-#{arch}/resources/app/resources/linux/code.png
+      Exec={{HOMEBREW_PREFIX}}/bin/code-insiders %F
+      Icon={{staged_path}}/vscode-insiders/resources/app/resources/linux/code.png
       Type=Application
       StartupNotify=false
       StartupWMClass=Code - Insiders
@@ -61,16 +62,16 @@ cask "visual-studio-code-linux@insiders" do
 
       [Desktop Action new-empty-window]
       Name=New Empty Window
-      Exec=#{HOMEBREW_PREFIX}/bin/code-insiders --new-window %F
-      Icon=#{staged_path}/VSCode-linux-#{arch}/resources/app/resources/linux/code.png
+      Exec={{HOMEBREW_PREFIX}}/bin/code-insiders --new-window %F
+      Icon={{staged_path}}/vscode-insiders/resources/app/resources/linux/code.png
     EOS
-    File.write("#{staged_path}/VSCode-linux-#{arch}/code-insiders-url-handler.desktop", <<~EOS)
+    write_file "vscode-insiders/code-insiders-url-handler.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code Insiders - URL Handler
       Comment=Code Editing. Redefined.
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/code-insiders --open-url %U
-      Icon=#{staged_path}/VSCode-linux-#{arch}/resources/app/resources/linux/code.png
+      Exec={{HOMEBREW_PREFIX}}/bin/code-insiders --open-url %U
+      Icon={{staged_path}}/vscode-insiders/resources/app/resources/linux/code.png
       Type=Application
       NoDisplay=true
       StartupNotify=true

--- a/Casks/vscodium-linux.rb
+++ b/Casks/vscodium-linux.rb
@@ -18,6 +18,8 @@ cask "vscodium-linux" do
     strategy :github_latest
   end
 
+  depends_on formula: "jq"
+
   binary "bin/codium"
   binary "bin/codium-tunnel"
   bash_completion "resources/completions/bash/codium"
@@ -29,26 +31,24 @@ cask "vscodium-linux" do
   artifact "resources/app/resources/linux/code.png",
            target: "#{Dir.home}/.local/share/icons/vscodium.png"
 
-  preflight do
-    # Disable VSCodium's built-in update checks; Homebrew manages this install.
-    product_json = "#{staged_path}/resources/app/product.json"
-    if File.exist?(product_json)
-      product = JSON.parse(File.read(product_json))
-      product.delete("updateUrl")
-      product["configurationDefaults"] ||= {}
-      product["configurationDefaults"]["update.mode"] = "none"
-      File.write(product_json, JSON.pretty_generate(product))
+  preflight_steps do
+    if_path_exists "resources/app/product.json" do
+      run "{{HOMEBREW_PREFIX}}/bin/jq",
+          args:        ["del(.updateUrl) | .configurationDefaults[\"update.mode\"] = \"none\"",
+                        "{{staged_path}}/resources/app/product.json"],
+          stdout_path: "product.json"
+      move "product.json", "resources/app/product.json"
     end
 
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons")
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons", base: :home
 
-    File.write("#{staged_path}/codium.desktop", <<~EOS)
+    write_file "codium.desktop", <<~EOS
       [Desktop Entry]
       Name=VSCodium
       Comment=Code Editing. Redefined.
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/codium %F
+      Exec={{HOMEBREW_PREFIX}}/bin/codium %F
       Icon=vscodium
       Type=Application
       StartupNotify=false
@@ -69,15 +69,15 @@ cask "vscodium-linux" do
       Name[ru]=Новое пустое окно
       Name[zh_CN]=新建空窗口
       Name[zh_TW]=開新空視窗
-      Exec=#{HOMEBREW_PREFIX}/bin/codium --new-window %F
+      Exec={{HOMEBREW_PREFIX}}/bin/codium --new-window %F
       Icon=vscodium
     EOS
-    File.write("#{staged_path}/codium-url-handler.desktop", <<~EOS)
+    write_file "codium-url-handler.desktop", <<~EOS
       [Desktop Entry]
       Name=VSCodium - URL Handler
       Comment=Code Editing. Redefined.
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/codium --open-url %U
+      Exec={{HOMEBREW_PREFIX}}/bin/codium --open-url %U
       Icon=vscodium
       Type=Application
       NoDisplay=true


### PR DESCRIPTION
## Summary

Current Homebrew rejects the tap’s remaining deprecated cask hooks, breaking [tap-wide CI](https://github.com/ublue-os/homebrew-tap/actions/runs/33978684792) and scheduled version bumps. This applies the same migration completed in the experimental tap.

1. **Migrate the remaining hooks.** Replace all 27 deprecated install and uninstall hooks across 15 casks with declarative `*_steps`.
2. **Move preparation into runtime steps.** Convert desktop integration, permissions, and service configuration to supported operations. Normalize architecture-dependent payload paths and declare `jq` for JSON edits and ASAR icon extraction.
3. **Keep wallpaper cleanup scoped.** Discover extracted files during installation rather than cask loading, and remove only cask-owned links during uninstall so shared directories retain other wallpapers and user files.

Versions and checksums are unchanged. This changes only cask files and retains the existing `brew test-bot` configuration.

Verified: Homebrew style, `readall --aliases --os=all --arch=all`, and audit excluding installed checks pass locally. Privileged 1Password integration and ASUS services still need testing on a supported host.

Related: https://github.com/ublue-os/homebrew-experimental-tap/pull/628
