### PR TITLE
fix: prevent cask sandbox installation failures

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -47,8 +47,9 @@ cask "1password-gui-linux" do
     symlink ".", ".user-home", source_base: :home, overwrite: true
     mkdir_p ".local/share/applications", base: :home
     mkdir_p ".local/share/icons", base: :home
-    inreplace "1password/resources/1password.desktop", "Exec=/opt/1Password/1password",
-              "Exec={{HOMEBREW_PREFIX}}/bin/1password"
+    # Do not declare the renamed file as a writable path before the move runs.
+    run "/bin/sed", args: ["-i", "s|Exec=/opt/1Password/1password|Exec={{HOMEBREW_PREFIX}}/bin/1password|g",
+                           "{{staged_path}}/1password/resources/1password.desktop"]
     run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
       printf '\nflatpak-session-helper\n' >> 1password/resources/custom_allowed_browsers
       owners=$(awk -F: '$3 >= 1000 && $3 <= 9999 && $1 != "nobody" && count++ < 10 {printf "unix-user:%s ", $1}' /etc/passwd)

--- a/Casks/asusctl-linux.rb
+++ b/Casks/asusctl-linux.rb
@@ -36,14 +36,16 @@ cask "asusctl-linux" do
   end
 
   postflight_steps do
-    copy "asusctl/usr/lib/systemd/system/asusd.service", "asusd.service"
-    inreplace "asusd.service", "Environment=ASUSD_EXEC=/usr/bin/asusd\n", "", audit_result: false
-    inreplace "asusd.service", "ExecStart=${ASUSD_EXEC}", "ExecStart=/opt/ublue-asusctl/bin/asusd"
-    copy "asusctl/usr/lib/systemd/system/asus-shutdown.service", "asus-shutdown.service"
-    inreplace "asus-shutdown.service", "Environment=ASUS_SHUTDOWN_EXEC=/usr/bin/asus-shutdown\n", "",
-              audit_result: false
-    inreplace "asus-shutdown.service", "ExecStart=${ASUS_SHUTDOWN_EXEC}",
-              "ExecStart=/opt/ublue-asusctl/bin/asus-shutdown"
+    # Generate files in the existing stage without predeclaring them as directories.
+    run "/bin/sed", args:        ["-e", "/^Environment=ASUSD_EXEC=/d",
+                                  "-e", "s|ExecStart=${ASUSD_EXEC}|ExecStart=/opt/ublue-asusctl/bin/asusd|",
+                                  "{{staged_path}}/asusctl/usr/lib/systemd/system/asusd.service"],
+                    stdout_path: "asusd.service"
+    run "/bin/sed", args:        ["-e", "/^Environment=ASUS_SHUTDOWN_EXEC=/d",
+                                  "-e",
+                                  "s|ExecStart=${ASUS_SHUTDOWN_EXEC}|ExecStart=/opt/ublue-asusctl/bin/asus-shutdown|",
+                                  "{{staged_path}}/asusctl/usr/lib/systemd/system/asus-shutdown.service"],
+                    stdout_path: "asus-shutdown.service"
     write_file "asusd.env", <<~EOS
       ASUSD_DATA_DIR=/opt/ublue-asusctl/share/asusd
       ASUSCTL_AURA_SUPPORT_PATH=/opt/ublue-asusctl/share/asusd/aura_support.ron

--- a/Casks/lm-studio-linux.rb
+++ b/Casks/lm-studio-linux.rb
@@ -33,7 +33,9 @@ cask "lm-studio-linux" do
     remove "LM-Studio-{{version}}-x64.AppImage"
     mkdir_p ".local/share/applications", base: :home
     mkdir_p ".local/share/icons", base: :home
-    inreplace "squashfs-root/ai.elementlabs.lmstudio.desktop", /^Exec=.*/, "Exec={{HOMEBREW_PREFIX}}/bin/lm-studio"
+    # The desktop file does not exist until the AppImage has been extracted.
+    run "/bin/sed", args: ["-i", "s|^Exec=.*|Exec={{HOMEBREW_PREFIX}}/bin/lm-studio|",
+                           "{{staged_path}}/squashfs-root/ai.elementlabs.lmstudio.desktop"]
   end
 
   zap trash: "~/.config/LMStudio"

--- a/Casks/rog-control-center-linux.rb
+++ b/Casks/rog-control-center-linux.rb
@@ -45,20 +45,30 @@ cask "rog-control-center-linux" do
     mkdir_p ".config/asusd", base: :home
     copy "asusctl/usr/share/asusd/.", ".local/share/asusd", target_base: :home, recursive: true
     copy "asusctl/usr/share/rog-gui/.", ".local/share/rog-gui", target_base: :home, recursive: true
-    copy "asusctl/usr/share/icons/hicolor/512x512/apps/*.png", ".local/share/icons/hicolor/512x512/apps",
-         target_base: :home, source_glob: true
-    copy "asusctl/usr/share/icons/hicolor/scalable/status/*.svg", ".local/share/icons/hicolor/scalable/status",
-         target_base: :home, source_glob: true
-    copy "asusctl/usr/share/applications/rog-control-center.desktop",
-         ".local/share/applications/rog-control-center.desktop", target_base: :home
-    inreplace ".local/share/applications/rog-control-center.desktop", /^Exec=.*/,
-              "Exec={{HOMEBREW_PREFIX}}/bin/rog-control-center", base: :home
-    copy "asusctl/usr/lib/systemd/user/asusd-user.service", ".config/systemd/user/asusd-user.service",
-         target_base: :home
-    inreplace ".config/systemd/user/asusd-user.service", "Environment=ASUSD_USER_EXEC=/usr/bin/asusd-user\n", "",
-              base: :home, audit_result: false
-    inreplace ".config/systemd/user/asusd-user.service", "ExecStart=${ASUSD_USER_EXEC}",
-              "ExecStart={{HOMEBREW_PREFIX}}/bin/asusd-user", base: :home
+    # Declarative source_glob only accepts one match; these icon sets contain several.
+    run "/bin/sh", chdir: "{{staged_path}}",
+                   writable_paths: [".local/share/icons/hicolor"], writable_base: :home,
+                   args: ["-eu", "-c", <<~SH]
+                     for icon in asusctl/usr/share/icons/hicolor/512x512/apps/*.png; do
+                       [ -f "$icon" ] || continue
+                       cp "$icon" .user-home/.local/share/icons/hicolor/512x512/apps/
+                     done
+                     for icon in asusctl/usr/share/icons/hicolor/scalable/status/*.svg; do
+                       [ -f "$icon" ] || continue
+                       cp "$icon" .user-home/.local/share/icons/hicolor/scalable/status/
+                     done
+                   SH
+    # Prepare files in the readable stage, then only write to the user's home.
+    run "/bin/sed", args:        ["s|^Exec=.*|Exec={{HOMEBREW_PREFIX}}/bin/rog-control-center|",
+                                  "{{staged_path}}/asusctl/usr/share/applications/rog-control-center.desktop"],
+                    stdout_path: "rog-control-center.desktop"
+    copy "rog-control-center.desktop", ".local/share/applications/rog-control-center.desktop", target_base: :home
+    run "/bin/sed", args:        ["-e", "/^Environment=ASUSD_USER_EXEC=/d",
+                                  "-e",
+                                  "s|ExecStart=${ASUSD_USER_EXEC}|ExecStart={{HOMEBREW_PREFIX}}/bin/asusd-user|",
+                                  "{{staged_path}}/asusctl/usr/lib/systemd/user/asusd-user.service"],
+                    stdout_path: "asusd-user.service"
+    copy "asusd-user.service", ".config/systemd/user/asusd-user.service", target_base: :home
     run "/bin/sh", chdir: "{{staged_path}}", writable_paths: [".config/asusd"], writable_base: :home,
                    args: ["-eu", "-c", <<~SH]
                      user_home=$(readlink .user-home)
@@ -68,12 +78,6 @@ cask "rog-control-center-linux" do
                        "ASUSCTL_AURA_SUPPORT_PATH=$user_home/.local/share/asusd/aura_support.ron" \
                        "ASUSCTL_DATA_DIRS=$user_home/.local/share" > .user-home/.config/asusd/asusd-user.env
                    SH
-    run "gtk-update-icon-cache", args: ["{{staged_path}}/.user-home/.local/share/icons/hicolor", "-f", "-t"],
-                                 must_succeed: false,
-                                 writable_paths: [".local/share/icons/hicolor"], writable_base: :home
-    run "update-desktop-database", args: ["{{staged_path}}/.user-home/.local/share/applications"],
-                                   must_succeed: false,
-                                   writable_paths: [".local/share/applications"], writable_base: :home
   end
 
   uninstall_postflight_steps do
@@ -88,12 +92,6 @@ cask "rog-control-center-linux" do
             ".local/share/icons/hicolor/scalable/status/notification-reboot.svg"], base: :home
     run "/bin/rmdir", args: ["{{staged_path}}/.user-home/.config/asusd"], must_succeed: false, print_stderr: false,
                       writable_paths: [".config/asusd"], writable_base: :home
-    run "gtk-update-icon-cache", args: ["{{staged_path}}/.user-home/.local/share/icons/hicolor", "-f", "-t"],
-                                 must_succeed: false,
-                                 writable_paths: [".local/share/icons/hicolor"], writable_base: :home
-    run "update-desktop-database", args: ["{{staged_path}}/.user-home/.local/share/applications"],
-                                   must_succeed: false,
-                                   writable_paths: [".local/share/applications"], writable_base: :home
   end
 
   zap trash: [
@@ -118,5 +116,10 @@ cask "rog-control-center-linux" do
     After the system daemon is installed and running, enable the user daemon:
       systemctl --user daemon-reload
       systemctl --user enable --now asusd-user.service
+
+    Shared desktop caches cannot be read inside the cask sandbox. If the launcher
+    or icons need refreshing after installation or removal, run:
+      gtk-update-icon-cache ~/.local/share/icons/hicolor -f -t
+      update-desktop-database ~/.local/share/applications
   EOS
 end

--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -39,10 +39,11 @@ cask "visual-studio-code-linux" do
         args:        ["del(.updateUrl) | .configurationDefaults[\"update.mode\"] = \"none\"",
                       "{{staged_path}}/vscode/resources/app/product.json"],
         stdout_path: "product.json"
-    move "product.json", "vscode/resources/app/product.json"
+    # Keep sandbox write declarations out of the not-yet-renamed directory.
+    run "/bin/mv", args: ["{{staged_path}}/product.json", "{{staged_path}}/vscode/resources/app/product.json"]
 
     mkdir_p ".local/share/applications", base: :home
-    write_file "vscode/code.desktop", <<~EOS
+    write_file "code.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code
       Comment=Code Editing. Redefined.
@@ -72,7 +73,7 @@ cask "visual-studio-code-linux" do
       Exec={{HOMEBREW_PREFIX}}/bin/code --new-window %F
       Icon={{staged_path}}/vscode/resources/app/resources/linux/code.png
     EOS
-    write_file "vscode/code-url-handler.desktop", <<~EOS
+    write_file "code-url-handler.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code - URL Handler
       Comment=Code Editing. Redefined.
@@ -86,6 +87,8 @@ cask "visual-studio-code-linux" do
       MimeType=x-scheme-handler/vscode;
       Keywords=vscode;
     EOS
+    run "/bin/mv", args: ["{{staged_path}}/code.desktop", "{{staged_path}}/code-url-handler.desktop",
+                          "{{staged_path}}/vscode/"]
   end
 
   zap trash: [

--- a/Casks/visual-studio-code-linux@insiders.rb
+++ b/Casks/visual-studio-code-linux@insiders.rb
@@ -8,7 +8,7 @@ cask "visual-studio-code-linux@insiders" do
          arm64_linux:  "0bd989f051f0faed32baede6014387fe5a8a5cf711beea39c0b4d55ad62bc053",
          x86_64_linux: "dace879714aa1be6e722de574bb1ab4b43505fd1c373d39e8cc116c9f83a2f82"
 
-  url "https://update.code.visualstudio.com/#{version.csv.first}/linux-#{arch}/insider"
+  url "https://update.code.visualstudio.com/commit:#{version.csv.second}/linux-#{arch}/insider"
   name "Microsoft Visual Studio Code Insiders"
   name "VS Code Insiders"
   desc "Open-source code editor (Insiders build)"
@@ -42,10 +42,12 @@ cask "visual-studio-code-linux@insiders" do
         args:        ["del(.updateUrl) | .configurationDefaults[\"update.mode\"] = \"none\"",
                       "{{staged_path}}/vscode-insiders/resources/app/product.json"],
         stdout_path: "product.json"
-    move "product.json", "vscode-insiders/resources/app/product.json"
+    # Keep sandbox write declarations out of the not-yet-renamed directory.
+    run "/bin/mv",
+        args: ["{{staged_path}}/product.json", "{{staged_path}}/vscode-insiders/resources/app/product.json"]
 
     mkdir_p ".local/share/applications", base: :home
-    write_file "vscode-insiders/code-insiders.desktop", <<~EOS
+    write_file "code-insiders.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code - Insiders
       Comment=Code Editing. Redefined.
@@ -65,7 +67,7 @@ cask "visual-studio-code-linux@insiders" do
       Exec={{HOMEBREW_PREFIX}}/bin/code-insiders --new-window %F
       Icon={{staged_path}}/vscode-insiders/resources/app/resources/linux/code.png
     EOS
-    write_file "vscode-insiders/code-insiders-url-handler.desktop", <<~EOS
+    write_file "code-insiders-url-handler.desktop", <<~EOS
       [Desktop Entry]
       Name=Visual Studio Code Insiders - URL Handler
       Comment=Code Editing. Redefined.
@@ -79,6 +81,9 @@ cask "visual-studio-code-linux@insiders" do
       MimeType=x-scheme-handler/vscode-insiders;
       Keywords=vscode;
     EOS
+    run "/bin/mv",
+        args: ["{{staged_path}}/code-insiders.desktop", "{{staged_path}}/code-insiders-url-handler.desktop",
+               "{{staged_path}}/vscode-insiders/"]
   end
 
   zap trash: [

--- a/Casks/zed-linux.rb
+++ b/Casks/zed-linux.rb
@@ -17,14 +17,13 @@ cask "zed-linux" do
   postflight_steps do
     mkdir_p ".local/share/applications", base: :home
     mkdir_p ".local/share/icons", base: :home
-    copy "zed.app/share/applications/dev.zed.Zed.desktop", ".local/share/applications/dev.zed.Zed.desktop",
-         target_base: :home
-    inreplace ".local/share/applications/dev.zed.Zed.desktop", /^TryExec=.*/, "TryExec={{HOMEBREW_PREFIX}}/bin/zed",
-              base: :home
-    inreplace ".local/share/applications/dev.zed.Zed.desktop", /^Exec=zed/, "Exec={{HOMEBREW_PREFIX}}/bin/zed",
-              base: :home
-    inreplace ".local/share/applications/dev.zed.Zed.desktop", /^Icon=.*/, "Icon=zed",
-              base: :home
+    # Prepare the launcher in the readable stage, then only write to the user's home.
+    run "/bin/sed", args:        ["-e", "s|^TryExec=.*|TryExec={{HOMEBREW_PREFIX}}/bin/zed|",
+                                  "-e", "s|^Exec=zed|Exec={{HOMEBREW_PREFIX}}/bin/zed|",
+                                  "-e", "s|^Icon=.*|Icon=zed|",
+                                  "{{staged_path}}/zed.app/share/applications/dev.zed.Zed.desktop"],
+                    stdout_path: "dev.zed.Zed.desktop"
+    copy "dev.zed.Zed.desktop", ".local/share/applications/dev.zed.Zed.desktop", target_base: :home
     copy "zed.app/share/icons/hicolor/512x512/apps/zed.png", ".local/share/icons/zed.png",
          target_base: :home
   end


### PR DESCRIPTION
## Summary

This fixes installation failures in seven Linux casks, including regressions from #627. Homebrew prepares sandbox writable paths before running the hooks, which can create directories where later steps expect files or rename destinations.

1. **Avoid premature path creation.** Adjust 1Password, LM Studio, asusctl, VS Code, and VS Code Insiders to generate or modify files without declaring nonexistent paths before extraction, copying, or renaming.

2. **Keep file preparation outside the home directory.** ROG Control Center and Zed now prepare their launchers and service files in the readable staging directory before copying them into place, avoiding sandbox home-read failures.

3. **Correct ROG icon handling.** Copy all matching icons rather than passing multiple matches to a single-source operation. Remove failing optional cache-refresh hooks and document manual refresh commands in the caveats.

4. **Pin the Insiders download.** Use the recorded build commit instead of the changing version URL. All versions and checksums remain unchanged.

Related: #627