### PR TITLE
fix(vscode): pin stable cask download URL to the build commit

### DIFF
--- a/Casks/visual-studio-code-linux.rb
+++ b/Casks/visual-studio-code-linux.rb
@@ -2,13 +2,13 @@ cask "visual-studio-code-linux" do
   arch arm: "arm64", intel: "x64"
   os linux: "linux"
 
-  version "1.136.1"
+  version "1.136.1,a44adf7f53e00964ab890f9f8758a334f1fc15bc"
   sha256 arm:          "2aac154ec452817e88c7b452b110f2cdbaad00af7bcf05ef7343891364e10c44",
          intel:        "9b4a54f0d49beaa413eda137d00c6541a639300d479efcac566ad13419409218",
          arm64_linux:  "2aac154ec452817e88c7b452b110f2cdbaad00af7bcf05ef7343891364e10c44",
          x86_64_linux: "9b4a54f0d49beaa413eda137d00c6541a639300d479efcac566ad13419409218"
 
-  url "https://update.code.visualstudio.com/#{version}/linux-#{arch}/stable"
+  url "https://update.code.visualstudio.com/commit:#{version.csv.second}/linux-#{arch}/stable"
   name "Microsoft Visual Studio Code"
   name "VS Code"
   desc "Open-source code editor"
@@ -17,7 +17,11 @@ cask "visual-studio-code-linux" do
   livecheck do
     url "https://update.code.visualstudio.com/api/update/linux-#{arch}/stable/latest"
     strategy :json do |json|
-      json["productVersion"]
+      version = json["productVersion"]
+      build = json["version"]
+      next if version.blank? || build.blank?
+
+      "#{version},#{build}"
     end
   end
 


### PR DESCRIPTION
## Summary

The insiders cask used to fail installs with a checksum mismatch whenever Microsoft rebuilt a release under the same product version, because the download URL floated to the newest build while the cask pinned the old sha256 (#592). PR #629 fixed that for insiders by addressing downloads by commit. The stable cask still uses the floating version URL, so the same race is open there, and it is worse in one way: stable's livecheck only tracks `productVersion`, so a rebuild under the same version never generates a bump PR and installs would stay broken until the next full release.

1. **Record the build commit in `version`.** The version becomes `1.136.1,a44adf7f...`, the same format the insiders cask already uses, so the URL, version, and sha256 travel as one atomic triple.

2. **Address the download by commit.** The `url` now uses `commit:#{version.csv.second}`, which Microsoft's update endpoint serves permanently, including superseded builds. An upstream rebuild can no longer change what this cask downloads.

3. **Track both fields in livecheck.** The strategy now emits `productVersion,commit` like the insiders cask, so a same-version rebuild produces a bump PR instead of passing unnoticed.

Verified: `commit:a44adf7f.../linux-{x64,arm64}/stable` downloads are byte-identical to the cask's recorded sha256 values, and the superseded insiders build `1f625adb` is still served by the commit endpoint, confirming old commits stay downloadable. Not yet exercised: a full `brew install` from this branch, and the bump workflow's first pass over the comma version, though it is the same shape the insiders cask already bumps with.

Related: #592, #629