### PR TITLE
fix(chairlift): import cask with reliable Linux setup

### DIFF
--- a/Casks/chairlift.rb
+++ b/Casks/chairlift.rb
@@ -1,0 +1,72 @@
+cask "chairlift" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "0.11.1"
+  sha256 arm:          "7c3d4461bad3a3ff438709d6ee98c98d680ef3f92ddbb3d204e953de538fccd2",
+         intel:        "dc153fe97661bb4a8db2e20353a5cb60290a45d99017df0dc83e58d075713360",
+         arm64_linux:  "7c3d4461bad3a3ff438709d6ee98c98d680ef3f92ddbb3d204e953de538fccd2",
+         x86_64_linux: "dc153fe97661bb4a8db2e20353a5cb60290a45d99017df0dc83e58d075713360"
+
+  url "https://github.com/frostyard/chairlift/releases/download/v#{version}/chairlift_#{version}_linux_#{arch}.tar.gz"
+  name "ChairLift"
+  desc "System management tool for bootc-based installations"
+  homepage "https://github.com/frostyard/chairlift"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :linux
+
+  binary "chairlift"
+  binary "data/chairlift-wrapper.sh", target: "chairlift-wrapper"
+
+  preflight_steps do
+    # Menu launches need the brew environment even when the session PATH lacks it.
+    inreplace "data/chairlift-wrapper.sh", "/home/linuxbrew/.linuxbrew/bin/brew", "{{HOMEBREW_PREFIX}}/bin/brew"
+    inreplace "data/chairlift-wrapper.sh", "$BREW_PATH shellenv", "\"$BREW_PATH\" shellenv bash"
+    inreplace "data/chairlift-wrapper.sh", "exec chairlift", "exec \"{{HOMEBREW_PREFIX}}/bin/chairlift\""
+    inreplace "data/org.frostyard.ChairLift.desktop", "Exec=chairlift-wrapper",
+              "Exec=\"{{HOMEBREW_PREFIX}}/bin/chairlift-wrapper\""
+  end
+
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    mkdir_p ".local/share/icons/hicolor/symbolic/apps", base: :home
+    copy "data/org.frostyard.ChairLift.desktop", ".local/share/applications/org.frostyard.ChairLift.desktop",
+         target_base: :home
+    copy "data/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg",
+         ".local/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg", target_base: :home
+    copy "data/icons/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg",
+         ".local/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg", target_base: :home
+    copy "data/icons/hicolor/symbolic/apps/org.frostyard.ChairLift-symbolic.svg",
+         ".local/share/icons/hicolor/symbolic/apps/org.frostyard.ChairLift-symbolic.svg", target_base: :home
+  end
+
+  uninstall_postflight_steps do
+    remove [".local/share/applications/org.frostyard.ChairLift.desktop",
+            ".local/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg",
+            ".local/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg",
+            ".local/share/icons/hicolor/symbolic/apps/org.frostyard.ChairLift-symbolic.svg"], base: :home
+  end
+
+  # Never link the privileged helper or install PolicyKit policies from a user-writable cask.
+  caveats <<~EOS
+    ChairLift requires GTK 4 and libadwaita 1 shared libraries from your OS.
+
+    Privileged features require the matching frostyard-chairlift-system-integration
+    package from https://github.com/frostyard/chairlift/releases installed by your
+    OS administrator or included in your OS image. This cask installs only the GUI
+    and desktop assets, not the root-owned helper or PolicyKit policies.
+    Bootc staging additionally requires /usr/libexec/bootc-update-stage from your OS.
+
+    Distribution configuration belongs in /etc/chairlift/config.yml; this cask
+    does not overwrite it. Upstream's bundled defaults target Snow Linux.
+
+    If the launcher or icons need refreshing after installation or removal, run:
+      gtk-update-icon-cache ~/.local/share/icons/hicolor -f -t
+      update-desktop-database ~/.local/share/applications
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ brew install --cask antigravity-cli-linux
 brew install --cask asusctl-linux
 brew install --cask rog-control-center-linux
 brew install --cask zed-linux
+brew install --cask ublue-os/tap/chairlift
 
 brew install --cask bluefin-wallpapers
 brew install --cask bluefin-wallpapers-extra
@@ -59,6 +60,27 @@ brew install --cask framework-wallpapers
 - Framework System Tool - Hardware management for Framework laptops
 - rog control center - GUI frontend for asusctl (for Asus ROG etc laptops)
 - Zed - High-performance, multiplayer code editor
+- ChairLift - System management and package updates for bootc-based Linux systems
+
+#### ChairLift
+
+ChairLift supports x86_64 and ARM64 Linux and requires GTK 4 and libadwaita 1
+from the host OS. The cask installs the GUI and user-local desktop assets only.
+Privileged features need the matching `frostyard-chairlift-system-integration`
+package from [upstream releases](https://github.com/frostyard/chairlift/releases)
+provided by the OS image or installed by an administrator. Bootc staging also
+needs the OS-provided `/usr/libexec/bootc-update-stage` helper.
+
+The bundled configuration targets Snow Linux. Distributions can override it in
+`/etc/chairlift/config.yml`, which this cask leaves untouched.
+
+If migrating from the Frostyard tap, uninstall its cask first to avoid conflicting
+binaries and desktop files, then install the fully qualified cask from this tap:
+
+```shell
+brew uninstall --cask frostyard/tap/chairlift
+brew install --cask ublue-os/tap/chairlift
+```
 
 ### Wallpapers
 


### PR DESCRIPTION
## Summary

This imports ChairLift from Frostyard’s tap and fixes checksum validation, deprecated hooks, and launcher assumptions before adding it to our tap.

1. **Update the release pin.** ChairLift 0.11.1 includes verified x86_64 and ARM64 checksums and an explicit Linux-only requirement.
2. **Use declarative installation steps.** Desktop files are prepared in staging before copying into the user’s home, following the fixes in #627 and #629. Uninstall removes the installed desktop assets.
3. **Fix launcher portability.** The wrapper uses the actual Homebrew prefix, requests Bash-compatible shell initialization, and launches the brew-managed binary directly.
4. **Document migration and privileged features.** The README explains migration from Frostyard’s cask and the separate OS-managed system-integration package.

Verified: Strict online audit across Homebrew’s OS/architecture matrix, style, readall, livecheck, both release checksums, isolated install-step and cleanup tests, and native `--help` passed. Full sandboxed installation, GUI operation, and privileged updates remain untested.

Related: #627, #629
