### PR TITLE
fix: handle 1Password desktop rename and replay

### DIFF
--- a/Casks/1password-gui-linux.rb
+++ b/Casks/1password-gui-linux.rb
@@ -43,15 +43,24 @@ cask "1password-gui-linux" do
            target: "#{HOMEBREW_PREFIX}/etc/1password/custom_allowed_browsers"
 
   preflight_steps do
-    move "1password-*", "1password", source_glob: true
+    # Rollback reuses the already-normalized payload directory.
+    unless_path_exists "1password" do
+      move "1password-*", "1password", source_glob: true
+    end
     symlink ".", ".user-home", source_base: :home, overwrite: true
     mkdir_p ".local/share/applications", base: :home
     mkdir_p ".local/share/icons", base: :home
-    # Do not declare the renamed file as a writable path before the move runs.
-    run "/bin/sed", args: ["-i", "s|Exec=/opt/1Password/1password|Exec={{HOMEBREW_PREFIX}}/bin/1password|g",
-                           "{{staged_path}}/1password/resources/1password.desktop"]
+    # Keep file preparation inside run: sandbox path setup must not create the
+    # destination directory before the payload move runs.
     run "/bin/sh", args: ["-eu", "-c", <<~'SH'], chdir: "{{staged_path}}"
-      printf '\nflatpak-session-helper\n' >> 1password/resources/custom_allowed_browsers
+      # 8.12.36 renamed the desktop file; retain the existing artifact/launcher path.
+      if [ -f 1password/resources/com.onepassword.OnePassword.desktop ]; then
+        mv 1password/resources/com.onepassword.OnePassword.desktop 1password/resources/1password.desktop
+      fi
+      sed -i 's|Exec=/opt/1Password/1password|Exec={{HOMEBREW_PREFIX}}/bin/1password|g' 1password/resources/1password.desktop
+      if ! grep -qxF flatpak-session-helper 1password/resources/custom_allowed_browsers; then
+        printf '\nflatpak-session-helper\n' >> 1password/resources/custom_allowed_browsers
+      fi
       owners=$(awk -F: '$3 >= 1000 && $3 <= 9999 && $1 != "nobody" && count++ < 10 {printf "unix-user:%s ", $1}' /etc/passwd)
       sed "s/\${POLICY_OWNERS}/$owners/g" 1password/com.1password.1Password.policy.tpl > 1password/com.1password.1Password.policy
     SH


### PR DESCRIPTION
## Summary

Upgrading `1password-gui-linux` to 8.12.36 fails because upstream renamed `resources/1password.desktop` to `resources/com.onepassword.OnePassword.desktop`. The cask still edits the old filename, and rollback also fails when it tries to rename an already-prepared payload directory.

1. **Handle the desktop filename change.** Normalize the new filename to the existing artifact path before updating its `Exec` entry, preserving the installed launcher path.
2. **Make preflight safe to replay.** Skip the payload rename when the normalized directory already exists and avoid adding duplicate browser allowlist entries.
3. **Add regression coverage.** Run Homebrew’s preflight runner against old and new desktop layouts with x64 and arm64 directory names, including replay checks, and add these tests to CI.

Verified: The downloaded 8.12.36 archive matches the cask’s checksum. Both original errors reproduce in isolated temporary directories with the unchanged cask. The fix passes all four layout fixtures, preflight and replay checks against the cached 8.12.34 and 8.12.36 x64 archives, and Homebrew style checks.
